### PR TITLE
Workflow definition contracts (#15): schema validation (#29) and discovery index (#30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.1",
+        "ajv": "^8.20.0",
         "gray-matter": "^4.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4490,10 +4491,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -6807,7 +6807,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -6868,7 +6867,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8556,7 +8554,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -12703,7 +12700,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
+    "ajv": "^8.20.0",
     "gray-matter": "^4.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/workflows/__fixtures__/bad-entry-node-id.json
+++ b/src/workflows/__fixtures__/bad-entry-node-id.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "bad-entry-node-id",
+  "name": "Bad Entry Node ID",
+  "version": "1.0.0",
+  "entry_node_id": "",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "terminal",
+      "name": "Done"
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/invalid-node-type.json
+++ b/src/workflows/__fixtures__/invalid-node-type.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "invalid-node-type",
+  "name": "Invalid Node Type",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "unsupported_type",
+      "name": "Bad Node"
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/missing-schema-version.json
+++ b/src/workflows/__fixtures__/missing-schema-version.json
@@ -1,0 +1,13 @@
+{
+  "workflow_id": "missing-schema-version",
+  "name": "Missing Schema Version",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "terminal",
+      "name": "Done"
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/valid-minimal.json
+++ b/src/workflows/__fixtures__/valid-minimal.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "test-minimal",
+  "name": "Test Minimal",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "terminal",
+      "name": "Done"
+    }
+  ]
+}

--- a/src/workflows/discoverWorkflowDefinitions.test.ts
+++ b/src/workflows/discoverWorkflowDefinitions.test.ts
@@ -1,0 +1,242 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    discoverWorkflowDefinitions,
+    WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+} from './discoverWorkflowDefinitions';
+import { resetWorkflowSchemaValidatorCacheForTests } from './validateWorkflowSchema';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+const tempDirs: string[] = [];
+
+function readFixture(name: string): unknown {
+    return JSON.parse(fs.readFileSync(path.join(fixturesDir, name), 'utf8'));
+}
+
+function createTempWorkspace(workflows: Record<string, unknown>): string {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-workflow-discovery-'));
+    tempDirs.push(tempDir);
+
+    const workflowsDir = path.join(tempDir, '.ai', 'workflows');
+    fs.mkdirSync(workflowsDir, { recursive: true });
+
+    for (const [filename, content] of Object.entries(workflows)) {
+        fs.writeFileSync(
+            path.join(workflowsDir, filename),
+            `${JSON.stringify(content, null, 2)}\n`,
+            'utf8'
+        );
+    }
+
+    return tempDir;
+}
+
+afterEach(() => {
+    resetWorkflowSchemaValidatorCacheForTests();
+
+    while (tempDirs.length > 0) {
+        const tempDir = tempDirs.pop();
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('discoverWorkflowDefinitions', () => {
+    it('returns one index entry per workflow JSON file with contract fields', () => {
+        const workspaceRoot = createTempWorkspace({
+            'alpha.json': readFixture('valid-minimal.json'),
+            'beta.json': {
+                schema_version: '1.0.0',
+                workflow_id: 'beta-flow',
+                name: 'Beta Flow',
+                version: '2.1.0',
+                description: 'Second workflow fixture',
+                entry_node_id: 'start',
+                nodes: [{ node_id: 'start', type: 'terminal', name: 'Done' }],
+            },
+        });
+
+        const result = discoverWorkflowDefinitions([workspaceRoot]);
+
+        expect(result.entries).toHaveLength(2);
+        expect(result.entries).toEqual(
+            expect.arrayContaining([
+                {
+                    workflow_id: 'test-minimal',
+                    name: 'Test Minimal',
+                    version: '1.0.0',
+                    schema_version: '1.0.0',
+                    path: '.ai/workflows/alpha.json',
+                    schema_valid: true,
+                },
+                {
+                    workflow_id: 'beta-flow',
+                    name: 'Beta Flow',
+                    version: '2.1.0',
+                    description: 'Second workflow fixture',
+                    schema_version: '1.0.0',
+                    path: '.ai/workflows/beta.json',
+                    schema_valid: true,
+                },
+            ])
+        );
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('discovers the repo refine-issue workflow definition', () => {
+        const result = discoverWorkflowDefinitions([process.cwd()]);
+
+        expect(result.entries).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    workflow_id: 'refine-issue',
+                    name: 'Refine Issue',
+                    version: '1.0.1',
+                    schema_version: '1.0.0',
+                    path: '.ai/workflows/refine-issue.json',
+                    schema_valid: true,
+                }),
+            ])
+        );
+    });
+
+    it('reports duplicate workflow_id values with forge.workflow.duplicate_id diagnostics', () => {
+        const workspaceRoot = createTempWorkspace({
+            'first.json': {
+                schema_version: '1.0.0',
+                workflow_id: 'shared-id',
+                name: 'First',
+                version: '1.0.0',
+                entry_node_id: 'start',
+                nodes: [{ node_id: 'start', type: 'terminal', name: 'Done' }],
+            },
+            'second.json': {
+                schema_version: '1.0.0',
+                workflow_id: 'shared-id',
+                name: 'Second',
+                version: '1.0.0',
+                entry_node_id: 'start',
+                nodes: [{ node_id: 'start', type: 'terminal', name: 'Done' }],
+            },
+        });
+
+        const result = discoverWorkflowDefinitions([workspaceRoot]);
+
+        expect(result.entries).toHaveLength(2);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                {
+                    code: 'forge.workflow.duplicate_id',
+                    severity: 'error',
+                    path: '.ai/workflows/first.json',
+                    message:
+                        'duplicate workflow_id "shared-id" across discovered workflow definition files',
+                    validator_id: WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+                },
+                {
+                    code: 'forge.workflow.duplicate_id',
+                    severity: 'error',
+                    path: '.ai/workflows/second.json',
+                    message:
+                        'duplicate workflow_id "shared-id" across discovered workflow definition files',
+                    validator_id: WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+                },
+            ])
+        );
+    });
+
+    it('returns an empty index when no workflow directory exists', () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-workflow-discovery-empty-'));
+        tempDirs.push(tempDir);
+
+        const result = discoverWorkflowDefinitions([tempDir]);
+
+        expect(result.entries).toEqual([]);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('continues scanning after invalid JSON and attaches schema_valid when validation runs', () => {
+        const workspaceRoot = createTempWorkspace({
+            'valid.json': readFixture('valid-minimal.json'),
+            'invalid.json': readFixture('missing-schema-version.json'),
+        });
+        fs.writeFileSync(
+            path.join(workspaceRoot, '.ai', 'workflows', 'broken.json'),
+            '{ invalid json',
+            'utf8'
+        );
+
+        const result = discoverWorkflowDefinitions([workspaceRoot]);
+
+        expect(result.entries).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    workflow_id: 'test-minimal',
+                    path: '.ai/workflows/valid.json',
+                    schema_valid: true,
+                }),
+                expect.objectContaining({
+                    workflow_id: 'missing-schema-version',
+                    path: '.ai/workflows/invalid.json',
+                    schema_valid: false,
+                }),
+            ])
+        );
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'forge.workflow.parse_error',
+                    severity: 'error',
+                    path: '.ai/workflows/broken.json',
+                }),
+            ])
+        );
+    });
+
+    it('skips schema validation when validateSchema is false', () => {
+        const workspaceRoot = createTempWorkspace({
+            'invalid.json': readFixture('missing-schema-version.json'),
+        });
+
+        const result = discoverWorkflowDefinitions([workspaceRoot], { validateSchema: false });
+
+        expect(result.entries).toEqual([
+            expect.objectContaining({
+                workflow_id: 'missing-schema-version',
+                path: '.ai/workflows/invalid.json',
+            }),
+        ]);
+        expect(result.entries[0]).not.toHaveProperty('schema_valid');
+    });
+
+    it('scans multiple workspace roots and detects duplicates across roots', () => {
+        const firstRoot = createTempWorkspace({
+            'alpha.json': {
+                schema_version: '1.0.0',
+                workflow_id: 'cross-root',
+                name: 'Alpha',
+                version: '1.0.0',
+                entry_node_id: 'start',
+                nodes: [{ node_id: 'start', type: 'terminal', name: 'Done' }],
+            },
+        });
+        const secondRoot = createTempWorkspace({
+            'beta.json': {
+                schema_version: '1.0.0',
+                workflow_id: 'cross-root',
+                name: 'Beta',
+                version: '1.0.0',
+                entry_node_id: 'start',
+                nodes: [{ node_id: 'start', type: 'terminal', name: 'Done' }],
+            },
+        });
+
+        const result = discoverWorkflowDefinitions([firstRoot, secondRoot]);
+
+        expect(result.entries).toHaveLength(2);
+        expect(result.diagnostics.filter((diagnostic) => diagnostic.code === 'forge.workflow.duplicate_id')).toHaveLength(2);
+    });
+});

--- a/src/workflows/discoverWorkflowDefinitions.ts
+++ b/src/workflows/discoverWorkflowDefinitions.ts
@@ -1,0 +1,161 @@
+import fs from 'fs';
+import path from 'path';
+import { validateWorkflowDefinitionJson } from './validateWorkflowSchema';
+import type {
+    WorkflowDefinitionIndexEntry,
+    WorkflowDiagnostic,
+    WorkflowDiscoveryResult,
+} from './types';
+
+export const WORKFLOW_DUPLICATE_ID_VALIDATOR_ID = 'forge.workflow.duplicate_id';
+
+const WORKFLOWS_RELATIVE_DIR = '.ai/workflows';
+
+export interface DiscoverWorkflowDefinitionsOptions {
+    validateSchema?: boolean;
+}
+
+interface ParsedWorkflowFile {
+    entry?: WorkflowDefinitionIndexEntry;
+    content?: unknown;
+    diagnostics: WorkflowDiagnostic[];
+    workflow_id?: string;
+}
+
+function toPosixRelativePath(workspaceRoot: string, absolutePath: string): string {
+    return path.relative(workspaceRoot, absolutePath).split(path.sep).join('/');
+}
+
+function listWorkflowJsonFiles(workspaceRoot: string): string[] {
+    const workflowsDir = path.join(workspaceRoot, WORKFLOWS_RELATIVE_DIR);
+    if (!fs.existsSync(workflowsDir) || !fs.statSync(workflowsDir).isDirectory()) {
+        return [];
+    }
+
+    return fs
+        .readdirSync(workflowsDir)
+        .filter((name) => name.endsWith('.json'))
+        .map((name) => path.join(workflowsDir, name));
+}
+
+function readStringField(record: Record<string, unknown>, key: string): string | undefined {
+    const value = record[key];
+    return typeof value === 'string' ? value : undefined;
+}
+
+function parseWorkflowFile(absolutePath: string, workspaceRoot: string): ParsedWorkflowFile {
+    const relativePath = toPosixRelativePath(workspaceRoot, absolutePath);
+    const filenameStem = path.basename(absolutePath, '.json');
+    const diagnostics: WorkflowDiagnostic[] = [];
+
+    let content: unknown;
+    try {
+        content = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'invalid JSON';
+        diagnostics.push({
+            code: 'forge.workflow.parse_error',
+            severity: 'error',
+            path: relativePath,
+            message: `failed to parse workflow definition: ${message}`,
+            validator_id: 'forge.workflow.schema',
+        });
+        return { diagnostics };
+    }
+
+    if (!content || typeof content !== 'object' || Array.isArray(content)) {
+        diagnostics.push({
+            code: 'schema.type',
+            severity: 'error',
+            path: relativePath,
+            message: 'workflow definition must be a JSON object',
+            validator_id: 'forge.workflow.schema',
+        });
+        return { diagnostics };
+    }
+
+    const record = content as Record<string, unknown>;
+    const workflow_id = readStringField(record, 'workflow_id') ?? filenameStem;
+    const entry: WorkflowDefinitionIndexEntry = {
+        workflow_id,
+        name: readStringField(record, 'name') ?? '',
+        version: readStringField(record, 'version') ?? '',
+        schema_version: readStringField(record, 'schema_version') ?? '',
+        path: relativePath,
+    };
+
+    const description = readStringField(record, 'description');
+    if (description !== undefined) {
+        entry.description = description;
+    }
+
+    return {
+        entry,
+        content,
+        diagnostics,
+        workflow_id,
+    };
+}
+
+function addDuplicateIdDiagnostics(
+    workflowId: string,
+    paths: string[],
+    diagnostics: WorkflowDiagnostic[]
+): void {
+    for (const filePath of paths) {
+        diagnostics.push({
+            code: 'forge.workflow.duplicate_id',
+            severity: 'error',
+            path: filePath,
+            message: `duplicate workflow_id "${workflowId}" across discovered workflow definition files`,
+            validator_id: WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+        });
+    }
+}
+
+export function discoverWorkflowDefinitions(
+    workspaceRoots: string[],
+    options?: DiscoverWorkflowDefinitionsOptions
+): WorkflowDiscoveryResult {
+    const validateSchema = options?.validateSchema !== false;
+    const entries: WorkflowDefinitionIndexEntry[] = [];
+    const diagnostics: WorkflowDiagnostic[] = [];
+    const workflowIdToPaths = new Map<string, string[]>();
+
+    for (const workspaceRoot of workspaceRoots) {
+        const absoluteRoot = path.resolve(workspaceRoot);
+
+        for (const filePath of listWorkflowJsonFiles(absoluteRoot)) {
+            const parsed = parseWorkflowFile(filePath, absoluteRoot);
+            diagnostics.push(...parsed.diagnostics);
+
+            if (!parsed.entry) {
+                continue;
+            }
+
+            if (validateSchema && parsed.content !== undefined) {
+                const validation = validateWorkflowDefinitionJson(parsed.content, {
+                    path: parsed.entry.path,
+                });
+                parsed.entry.schema_valid = validation.valid;
+            }
+
+            entries.push(parsed.entry);
+
+            const workflowId = parsed.workflow_id ?? parsed.entry.workflow_id;
+            const existingPaths = workflowIdToPaths.get(workflowId) ?? [];
+            existingPaths.push(parsed.entry.path);
+            workflowIdToPaths.set(workflowId, existingPaths);
+        }
+    }
+
+    for (const [workflowId, paths] of workflowIdToPaths) {
+        if (paths.length > 1) {
+            addDuplicateIdDiagnostics(workflowId, paths, diagnostics);
+        }
+    }
+
+    entries.sort((left, right) => left.workflow_id.localeCompare(right.workflow_id));
+
+    return { entries, diagnostics };
+}

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,0 +1,16 @@
+export type WorkflowDiagnosticSeverity = 'error' | 'warning';
+
+export interface WorkflowDiagnostic {
+    code: string;
+    severity: WorkflowDiagnosticSeverity;
+    path: string;
+    message: string;
+    validator_id: string;
+}
+
+export interface WorkflowSchemaValidationResult {
+    valid: boolean;
+    diagnostics: WorkflowDiagnostic[];
+    workflow_id?: string;
+    path?: string;
+}

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -14,3 +14,18 @@ export interface WorkflowSchemaValidationResult {
     workflow_id?: string;
     path?: string;
 }
+
+export interface WorkflowDefinitionIndexEntry {
+    workflow_id: string;
+    name: string;
+    version: string;
+    description?: string;
+    schema_version: string;
+    path: string;
+    schema_valid?: boolean;
+}
+
+export interface WorkflowDiscoveryResult {
+    entries: WorkflowDefinitionIndexEntry[];
+    diagnostics: WorkflowDiagnostic[];
+}

--- a/src/workflows/validateWorkflowSchema.test.ts
+++ b/src/workflows/validateWorkflowSchema.test.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    validateWorkflowDefinitionJson,
+    WORKFLOW_SCHEMA_VALIDATOR_ID,
+    resetWorkflowSchemaValidatorCacheForTests,
+} from './validateWorkflowSchema';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+
+function readFixture(name: string): unknown {
+    return JSON.parse(fs.readFileSync(path.join(fixturesDir, name), 'utf8'));
+}
+
+describe('validateWorkflowDefinitionJson', () => {
+    beforeEach(() => {
+        resetWorkflowSchemaValidatorCacheForTests();
+    });
+
+    it('accepts a valid minimal workflow fixture', () => {
+        const content = readFixture('valid-minimal.json');
+        const result = validateWorkflowDefinitionJson(content, {
+            path: '.ai/workflows/test-minimal.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+        expect(result.workflow_id).toBe('test-minimal');
+        expect(result.path).toBe('.ai/workflows/test-minimal.json');
+    });
+
+    it('validates the repo refine-issue workflow definition', () => {
+        const refineIssuePath = path.join(process.cwd(), '.ai/workflows/refine-issue.json');
+        const content = JSON.parse(fs.readFileSync(refineIssuePath, 'utf8'));
+        const result = validateWorkflowDefinitionJson(content, {
+            path: '.ai/workflows/refine-issue.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+        expect(result.workflow_id).toBe('refine-issue');
+    });
+
+    it('reports missing schema_version with forge.workflow.schema diagnostics', () => {
+        const content = readFixture('missing-schema-version.json');
+        const result = validateWorkflowDefinitionJson(content);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics.length).toBeGreaterThan(0);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'schema.required',
+                    severity: 'error',
+                    path: '/schema_version',
+                    validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('reports invalid entry_node_id constraint failures', () => {
+        const content = readFixture('bad-entry-node-id.json');
+        const result = validateWorkflowDefinitionJson(content);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'schema.constraint',
+                    severity: 'error',
+                    path: '/entry_node_id',
+                    validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('reports invalid node type enum failures', () => {
+        const content = readFixture('invalid-node-type.json');
+        const result = validateWorkflowDefinitionJson(content);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'schema.enum',
+                    severity: 'error',
+                    path: '/nodes/0/type',
+                    validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('rejects non-object workflow content', () => {
+        const result = validateWorkflowDefinitionJson('not-an-object');
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual([
+            {
+                code: 'schema.type',
+                severity: 'error',
+                path: '/',
+                message: 'workflow definition must be a JSON object',
+                validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+            },
+        ]);
+    });
+});

--- a/src/workflows/validateWorkflowSchema.ts
+++ b/src/workflows/validateWorkflowSchema.ts
@@ -1,0 +1,150 @@
+import fs from 'fs';
+import path from 'path';
+import Ajv2020, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';
+import type { WorkflowDiagnostic, WorkflowSchemaValidationResult } from './types';
+
+export const WORKFLOW_SCHEMA_VALIDATOR_ID = 'forge.workflow.schema';
+
+const WORKFLOW_SCHEMA_RELATIVE_PATH = '.ai/schemas/workflow.schema.json';
+
+let cachedValidator: ValidateFunction | undefined;
+
+function resolveWorkflowSchemaPath(): string {
+    const candidates = [
+        path.join(process.cwd(), WORKFLOW_SCHEMA_RELATIVE_PATH),
+        path.join(__dirname, '../../.ai/schemas/workflow.schema.json'),
+    ];
+
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    throw new Error(`workflow schema not found (expected ${WORKFLOW_SCHEMA_RELATIVE_PATH})`);
+}
+
+function loadWorkflowSchemaValidator(): ValidateFunction {
+    if (cachedValidator) {
+        return cachedValidator;
+    }
+
+    const schemaPath = resolveWorkflowSchemaPath();
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as object;
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    cachedValidator = ajv.compile(schema);
+    return cachedValidator;
+}
+
+function diagnosticCodeForAjvError(error: ErrorObject): string {
+    const keyword = error.keyword;
+
+    switch (keyword) {
+        case 'required':
+            return 'schema.required';
+        case 'type':
+            return 'schema.type';
+        case 'enum':
+            return 'schema.enum';
+        case 'const':
+            return 'schema.const';
+        case 'additionalProperties':
+            return 'schema.additional_properties';
+        case 'minLength':
+        case 'minItems':
+        case 'pattern':
+            return 'schema.constraint';
+        default:
+            return `schema.${keyword}`;
+    }
+}
+
+function jsonPointerFromAjvError(error: ErrorObject): string {
+    const instancePath = error.instancePath || '';
+    if (instancePath.length > 0) {
+        return instancePath;
+    }
+
+    if (error.keyword === 'required' && error.params.missingProperty) {
+        return `/${String(error.params.missingProperty)}`;
+    }
+
+    return '/';
+}
+
+function messageForAjvError(error: ErrorObject): string {
+    if (error.message) {
+        return error.message;
+    }
+
+    return `JSON Schema validation failed (${error.keyword})`;
+}
+
+function mapAjvErrorToDiagnostic(error: ErrorObject): WorkflowDiagnostic {
+    return {
+        code: diagnosticCodeForAjvError(error),
+        severity: 'error',
+        path: jsonPointerFromAjvError(error),
+        message: messageForAjvError(error),
+        validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+    };
+}
+
+function extractWorkflowId(content: unknown): string | undefined {
+    if (!content || typeof content !== 'object' || Array.isArray(content)) {
+        return undefined;
+    }
+
+    const workflowId = (content as Record<string, unknown>).workflow_id;
+    return typeof workflowId === 'string' && workflowId.length > 0 ? workflowId : undefined;
+}
+
+export function validateWorkflowDefinitionJson(
+    content: unknown,
+    options?: { path?: string }
+): WorkflowSchemaValidationResult {
+    const workflow_id = extractWorkflowId(content);
+    const definitionPath = options?.path;
+
+    if (content === null || typeof content !== 'object' || Array.isArray(content)) {
+        const diagnostic: WorkflowDiagnostic = {
+            code: 'schema.type',
+            severity: 'error',
+            path: '/',
+            message: 'workflow definition must be a JSON object',
+            validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+        };
+
+        return {
+            valid: false,
+            diagnostics: [diagnostic],
+            workflow_id,
+            path: definitionPath,
+        };
+    }
+
+    const validate = loadWorkflowSchemaValidator();
+    const valid = validate(content);
+
+    if (valid) {
+        return {
+            valid: true,
+            diagnostics: [],
+            workflow_id,
+            path: definitionPath,
+        };
+    }
+
+    const diagnostics = (validate.errors ?? []).map(mapAjvErrorToDiagnostic);
+
+    return {
+        valid: false,
+        diagnostics,
+        workflow_id,
+        path: definitionPath,
+    };
+}
+
+export function resetWorkflowSchemaValidatorCacheForTests(): void {
+    cachedValidator = undefined;
+}


### PR DESCRIPTION
## Description

Adds workflow definition infrastructure for parent epic #15:

1. **Structural schema validation (#29)** — `validateWorkflowDefinitionJson` validates parsed workflow JSON against `.ai/schemas/workflow.schema.json` and returns diagnostics aligned with `.ai/data/serialization.md`.
2. **Discovery index (#30)** — `discoverWorkflowDefinitions` scans workspace folder roots for `.ai/workflows/*.json`, returns stable index entries (`workflow_id`, `name`, `version`, `description`, `schema_version`, `path`), optionally attaches `schema_valid`, and reports duplicate `workflow_id` values via `forge.workflow.duplicate_id` diagnostics.

## Motivation and Context

Parent epic #15 needs repo-owned workflow definitions discoverable and structurally validated before domain/graph validation (#16) and Studio listing. Sub-issues #29 and #30 ship the shared modules and Vitest coverage on `feature/issue-15`.

Part of #15. Closes #29. Closes #30.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

```bash
cd forge
npm ci
npm run lint
npm run build
npm test
```

Coverage includes:
- Schema validation fixtures (valid minimal, missing `schema_version`, invalid graph fields, non-object input)
- Repo `refine-issue.json` workflow definition
- Discovery index for multiple workflow files with contract fields
- Duplicate `workflow_id` diagnostics across files and workspace roots
- Invalid JSON handling without crashing the scan
- Optional `schema_valid` attachment when structural validation runs

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] My changes generate no new warnings

## Additional Notes

- Uses `ajv` draft 2020-12 validator with `validator_id: forge.workflow.schema`
- Graph/domain validation and Studio React Flow UI remain out of scope (#16)