### PR TITLE
Validate workflow definitions before runs (#16)

### DIFF
--- a/src/workflows/__fixtures__/broken-transition.json
+++ b/src/workflows/__fixtures__/broken-transition.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "broken-transition",
+  "name": "Broken Transition",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "activity",
+      "name": "Start",
+      "activity_id": "forge.test.start",
+      "agent_path": "resources/workflow/agents/technical-writer.md",
+      "transitions": [
+        { "to_node_id": "missing-node" }
+      ]
+    },
+    {
+      "node_id": "done",
+      "type": "terminal",
+      "name": "Done"
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/missing-binding.json
+++ b/src/workflows/__fixtures__/missing-binding.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "missing-binding",
+  "name": "Missing Binding",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "activity",
+      "name": "Start",
+      "activity_id": "forge.test.start",
+      "transitions": [
+        { "to_node_id": "done" }
+      ]
+    },
+    {
+      "node_id": "done",
+      "type": "terminal",
+      "name": "Done"
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/no-terminal-reachable.json
+++ b/src/workflows/__fixtures__/no-terminal-reachable.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "no-terminal-reachable",
+  "name": "No Terminal Reachable",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "activity",
+      "name": "Start",
+      "activity_id": "forge.test.start",
+      "agent_path": "resources/workflow/agents/technical-writer.md",
+      "transitions": [
+        { "to_node_id": "loop" }
+      ]
+    },
+    {
+      "node_id": "loop",
+      "type": "activity",
+      "name": "Loop",
+      "activity_id": "forge.test.loop",
+      "agent_path": "resources/workflow/agents/technical-writer.md",
+      "transitions": [
+        { "to_node_id": "start" }
+      ]
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/orphan-node.json
+++ b/src/workflows/__fixtures__/orphan-node.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0.0",
+  "workflow_id": "orphan-node",
+  "name": "Orphan Node",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "terminal",
+      "name": "Done"
+    },
+    {
+      "node_id": "orphaned",
+      "type": "terminal",
+      "name": "Unreachable"
+    }
+  ]
+}

--- a/src/workflows/__fixtures__/unsupported-version.json
+++ b/src/workflows/__fixtures__/unsupported-version.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "2.0.0",
+  "workflow_id": "unsupported-version",
+  "name": "Unsupported Version",
+  "version": "1.0.0",
+  "entry_node_id": "start",
+  "nodes": [
+    {
+      "node_id": "start",
+      "type": "terminal",
+      "name": "Done"
+    }
+  ]
+}

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,0 +1,38 @@
+export {
+    discoverWorkflowDefinitions,
+    WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+} from './discoverWorkflowDefinitions';
+export {
+    PRE_RUN_VALIDATOR_IDS,
+    RUNTIME_ONLY_VALIDATOR_IDS,
+    isPreRunValidatorId,
+} from './preRunValidatorScope';
+export type { PreRunValidatorId } from './preRunValidatorScope';
+export type {
+    Diagnostic,
+    ValidationResult,
+    WorkflowDefinitionIndexEntry,
+    WorkflowDiagnostic,
+    WorkflowDiscoveryResult,
+    WorkflowSchemaValidationResult,
+} from './types';
+export {
+    validateWorkflowDefinition,
+    validateWorkflowDefinitionFile,
+} from './validateWorkflowDefinition';
+export {
+    WORKFLOW_BINDING_VALIDATOR_ID,
+    WORKFLOW_GRAPH_VALIDATOR_ID,
+    WORKFLOW_ORPHAN_NODE_CODE,
+    WORKFLOW_UNSUPPORTED_VERSION_VALIDATOR_ID,
+    validateWorkflowDomain,
+} from './validateWorkflowDomain';
+export {
+    WORKFLOW_SCHEMA_VALIDATOR_ID,
+    validateWorkflowDefinitionJson,
+} from './validateWorkflowSchema';
+export {
+    WorkflowRunStartBlockedError,
+    gateWorkflowRunStart,
+    validateWorkflowForRun,
+} from './validateWorkflowForRun';

--- a/src/workflows/preRunValidatorScope.test.ts
+++ b/src/workflows/preRunValidatorScope.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+    PRE_RUN_VALIDATOR_IDS,
+    RUNTIME_ONLY_VALIDATOR_IDS,
+    isPreRunValidatorId,
+} from './preRunValidatorScope';
+
+describe('preRunValidatorScope', () => {
+    it('lists the pre-run validator catalog from domain_model.md', () => {
+        expect(PRE_RUN_VALIDATOR_IDS).toEqual([
+            'forge.workflow.schema',
+            'forge.workflow.graph',
+            'forge.workflow.binding',
+            'forge.workflow.duplicate_id',
+            'forge.workflow.unsupported_version',
+            'forge.artifact.declared',
+        ]);
+    });
+
+    it('excludes runtime-only validators from pre-run scope', () => {
+        for (const runtimeId of RUNTIME_ONLY_VALIDATOR_IDS) {
+            expect(isPreRunValidatorId(runtimeId)).toBe(false);
+            expect(PRE_RUN_VALIDATOR_IDS).not.toContain(runtimeId);
+        }
+    });
+});

--- a/src/workflows/preRunValidatorScope.ts
+++ b/src/workflows/preRunValidatorScope.ts
@@ -1,0 +1,25 @@
+/**
+ * Pre-run validator scope per `.ai/business_logic/domain_model.md`.
+ * Definition validation and run-start gates use only these IDs.
+ */
+export const PRE_RUN_VALIDATOR_IDS = [
+    'forge.workflow.schema',
+    'forge.workflow.graph',
+    'forge.workflow.binding',
+    'forge.workflow.duplicate_id',
+    'forge.workflow.unsupported_version',
+    'forge.artifact.declared',
+] as const;
+
+/** Runtime validation node validators that must not execute during pre-run. */
+export const RUNTIME_ONLY_VALIDATOR_IDS = [
+    'forge.artifact.exists',
+    'forge.artifact.schema',
+    'forge.domain.exit_criteria',
+] as const;
+
+export type PreRunValidatorId = (typeof PRE_RUN_VALIDATOR_IDS)[number];
+
+export function isPreRunValidatorId(validatorId: string): validatorId is PreRunValidatorId {
+    return (PRE_RUN_VALIDATOR_IDS as readonly string[]).includes(validatorId);
+}

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -8,12 +8,18 @@ export interface WorkflowDiagnostic {
     validator_id: string;
 }
 
+/** Pre-run validation diagnostic (alias for discovery and run-start gates). */
+export type Diagnostic = WorkflowDiagnostic;
+
 export interface WorkflowSchemaValidationResult {
     valid: boolean;
     diagnostics: WorkflowDiagnostic[];
     workflow_id?: string;
     path?: string;
 }
+
+/** Aggregate pre-run validation result per `.ai/data/serialization.md`. */
+export type ValidationResult = WorkflowSchemaValidationResult;
 
 export interface WorkflowDefinitionIndexEntry {
     workflow_id: string;

--- a/src/workflows/validateWorkflowDefinition.test.ts
+++ b/src/workflows/validateWorkflowDefinition.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    validateWorkflowDefinition,
+    validateWorkflowDefinitionFile,
+} from './validateWorkflowDefinition';
+import {
+    WORKFLOW_BINDING_VALIDATOR_ID,
+    WORKFLOW_GRAPH_VALIDATOR_ID,
+} from './validateWorkflowDomain';
+import {
+    WORKFLOW_SCHEMA_VALIDATOR_ID,
+    resetWorkflowSchemaValidatorCacheForTests,
+} from './validateWorkflowSchema';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+
+function readFixture(name: string): unknown {
+    return JSON.parse(fs.readFileSync(path.join(fixturesDir, name), 'utf8'));
+}
+
+describe('validateWorkflowDefinition', () => {
+    beforeEach(() => {
+        resetWorkflowSchemaValidatorCacheForTests();
+    });
+
+    it('accepts a valid minimal workflow on the happy path', () => {
+        const content = readFixture('valid-minimal.json');
+        const result = validateWorkflowDefinition(content, {
+            path: '.ai/workflows/test-minimal.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+        expect(result.workflow_id).toBe('test-minimal');
+        expect(result.path).toBe('.ai/workflows/test-minimal.json');
+    });
+
+    it('reports schema-only failures before domain diagnostics', () => {
+        const content = readFixture('missing-schema-version.json');
+        const result = validateWorkflowDefinition(content, {
+            path: '.ai/workflows/missing-schema-version.json',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics[0]).toEqual(
+            expect.objectContaining({
+                code: 'schema.required',
+                severity: 'error',
+                validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+            })
+        );
+        expect(result.diagnostics.every((diagnostic) => diagnostic.validator_id !== WORKFLOW_GRAPH_VALIDATOR_ID)).toBe(
+            true
+        );
+    });
+
+    it('reports domain-only failures when schema passes', () => {
+        const content = readFixture('broken-transition.json');
+        const result = validateWorkflowDefinition(content, {
+            path: '.ai/workflows/broken-transition.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'graph.missing_transition_target',
+                    severity: 'error',
+                    validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+                }),
+            ])
+        );
+        expect(result.diagnostics.some((diagnostic) => diagnostic.validator_id === WORKFLOW_SCHEMA_VALIDATOR_ID)).toBe(
+            false
+        );
+    });
+
+    it('merges schema and domain failures with schema diagnostics first', () => {
+        const content = {
+            workflow_id: 'combined-fail',
+            name: 'Combined Fail',
+            version: '1.0.0',
+            entry_node_id: 'start',
+            nodes: [
+                {
+                    node_id: 'start',
+                    type: 'activity',
+                    name: 'Start',
+                    activity_id: 'forge.test.start',
+                    transitions: [{ to_node_id: 'done' }],
+                },
+                {
+                    node_id: 'done',
+                    type: 'terminal',
+                    name: 'Done',
+                },
+            ],
+        };
+
+        const result = validateWorkflowDefinition(content, {
+            path: '.ai/workflows/combined-fail.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics[0]).toEqual(
+            expect.objectContaining({
+                code: 'schema.required',
+                severity: 'error',
+                validator_id: WORKFLOW_SCHEMA_VALIDATOR_ID,
+            })
+        );
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'binding.missing_agent_or_skill_path',
+                    severity: 'error',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('keeps valid true when only warnings are present', () => {
+        const content = readFixture('orphan-node.json');
+        const result = validateWorkflowDefinition(content, {
+            path: '.ai/workflows/orphan-node.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'graph.orphan_node',
+                    severity: 'warning',
+                }),
+            ])
+        );
+    });
+
+    it('loads and validates a definition file from disk', () => {
+        const definitionPath = path.join(process.cwd(), '.ai/workflows/refine-issue.json');
+        const result = validateWorkflowDefinitionFile(definitionPath, {
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.workflow_id).toBe('refine-issue');
+        expect(result.path).toBe('.ai/workflows/refine-issue.json');
+    });
+});

--- a/src/workflows/validateWorkflowDefinition.ts
+++ b/src/workflows/validateWorkflowDefinition.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+import { validateWorkflowDomain } from './validateWorkflowDomain';
+import { validateWorkflowDefinitionJson } from './validateWorkflowSchema';
+import type { ValidationResult, WorkflowDiagnostic } from './types';
+
+export interface ValidateWorkflowDefinitionOptions {
+    path: string;
+    workspaceRoot?: string;
+    discoveredWorkflowIds?: string[];
+}
+
+function aggregateValid(diagnostics: WorkflowDiagnostic[]): boolean {
+    return !diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+}
+
+function mergeValidationResults(
+    schemaResult: ValidationResult,
+    domainResult: ValidationResult
+): ValidationResult {
+    const diagnostics = [...schemaResult.diagnostics, ...domainResult.diagnostics];
+
+    return {
+        valid: aggregateValid(diagnostics),
+        diagnostics,
+        workflow_id: schemaResult.workflow_id ?? domainResult.workflow_id,
+        path: schemaResult.path ?? domainResult.path,
+    };
+}
+
+export function validateWorkflowDefinition(
+    content: unknown,
+    options: ValidateWorkflowDefinitionOptions
+): ValidationResult {
+    const schemaResult = validateWorkflowDefinitionJson(content, { path: options.path });
+    const domainResult = validateWorkflowDomain(content, {
+        path: options.path,
+        workspaceRoot: options.workspaceRoot,
+        discoveredWorkflowIds: options.discoveredWorkflowIds,
+    });
+
+    return mergeValidationResults(schemaResult, domainResult);
+}
+
+function toPosixPath(repoRelativePath: string): string {
+    return repoRelativePath.split(path.sep).join('/');
+}
+
+export function validateWorkflowDefinitionFile(
+    definitionPath: string,
+    options?: Omit<ValidateWorkflowDefinitionOptions, 'path'>
+): ValidationResult {
+    const workspaceRoot = options?.workspaceRoot ? path.resolve(options.workspaceRoot) : undefined;
+    const absolutePath = path.isAbsolute(definitionPath)
+        ? path.resolve(definitionPath)
+        : workspaceRoot
+          ? path.join(workspaceRoot, definitionPath)
+          : path.resolve(definitionPath);
+    const relativePath = workspaceRoot
+        ? toPosixPath(path.relative(workspaceRoot, absolutePath))
+        : toPosixPath(definitionPath);
+
+    let content: unknown;
+    try {
+        content = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'invalid JSON';
+        const diagnostic: WorkflowDiagnostic = {
+            code: 'forge.workflow.parse_error',
+            severity: 'error',
+            path: relativePath,
+            message: `failed to parse workflow definition: ${message}`,
+            validator_id: 'forge.workflow.schema',
+        };
+
+        return {
+            valid: false,
+            diagnostics: [diagnostic],
+            path: relativePath,
+        };
+    }
+
+    return validateWorkflowDefinition(content, {
+        path: relativePath,
+        workspaceRoot: options?.workspaceRoot,
+        discoveredWorkflowIds: options?.discoveredWorkflowIds,
+    });
+}

--- a/src/workflows/validateWorkflowDomain.test.ts
+++ b/src/workflows/validateWorkflowDomain.test.ts
@@ -1,0 +1,228 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+    validateWorkflowDomain,
+    WORKFLOW_BINDING_VALIDATOR_ID,
+    WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+    WORKFLOW_GRAPH_VALIDATOR_ID,
+    WORKFLOW_ORPHAN_NODE_CODE,
+    WORKFLOW_UNSUPPORTED_VERSION_VALIDATOR_ID,
+} from './validateWorkflowDomain';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+
+function readFixture(name: string): unknown {
+    return JSON.parse(fs.readFileSync(path.join(fixturesDir, name), 'utf8'));
+}
+
+describe('validateWorkflowDomain', () => {
+    it('accepts a valid minimal workflow fixture', () => {
+        const content = readFixture('valid-minimal.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/test-minimal.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+        expect(result.workflow_id).toBe('test-minimal');
+    });
+
+    it('validates the repo refine-issue workflow definition with binding paths', () => {
+        const refineIssuePath = path.join(process.cwd(), '.ai/workflows/refine-issue.json');
+        const content = JSON.parse(fs.readFileSync(refineIssuePath, 'utf8'));
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/refine-issue.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+        expect(result.workflow_id).toBe('refine-issue');
+    });
+
+    it('reports broken transition targets as graph errors', () => {
+        const content = readFixture('broken-transition.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/broken-transition.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'graph.missing_transition_target',
+                    severity: 'error',
+                    path: '/nodes/0/transitions/0/to_node_id',
+                    validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+                }),
+                expect.objectContaining({
+                    code: 'graph.unreachable_terminal',
+                    severity: 'error',
+                    validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('reports missing activity bindings as errors', () => {
+        const content = readFixture('missing-binding.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/missing-binding.json',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'binding.missing_agent_or_skill_path',
+                    severity: 'error',
+                    path: '/nodes/0',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('reports orphan nodes as warnings without failing validation', () => {
+        const content = readFixture('orphan-node.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/orphan-node.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([
+            expect.objectContaining({
+                code: WORKFLOW_ORPHAN_NODE_CODE,
+                severity: 'warning',
+                path: '/nodes/1',
+                validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+            }),
+        ]);
+    });
+
+    it('reports duplicate workflow_id values from discovery context', () => {
+        const content = readFixture('valid-minimal.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/test-minimal.json',
+            discoveredWorkflowIds: ['test-minimal', 'test-minimal', 'other-flow'],
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual([
+            expect.objectContaining({
+                code: 'forge.workflow.duplicate_id',
+                severity: 'error',
+                path: '.ai/workflows/test-minimal.json',
+                validator_id: WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+            }),
+        ]);
+    });
+
+    it('reports unsupported schema_version majors', () => {
+        const content = readFixture('unsupported-version.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/unsupported-version.json',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual([
+            expect.objectContaining({
+                code: 'forge.workflow.unsupported_version',
+                severity: 'error',
+                path: '/schema_version',
+                validator_id: WORKFLOW_UNSUPPORTED_VERSION_VALIDATOR_ID,
+            }),
+        ]);
+    });
+
+    it('reports when no terminal node is reachable from entry', () => {
+        const content = readFixture('no-terminal-reachable.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/no-terminal-reachable.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'graph.unreachable_terminal',
+                    severity: 'error',
+                    validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('reports filename stem mismatch under binding rules', () => {
+        const content = readFixture('valid-minimal.json');
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/wrong-stem.json',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'binding.filename_stem_mismatch',
+                    severity: 'error',
+                    path: '.ai/workflows/wrong-stem.json',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('reports unresolved binding paths when workspaceRoot is provided', () => {
+        const content = {
+            schema_version: '1.0.0',
+            workflow_id: 'bad-path',
+            name: 'Bad Path',
+            version: '1.0.0',
+            entry_node_id: 'start',
+            nodes: [
+                {
+                    node_id: 'start',
+                    type: 'activity',
+                    name: 'Start',
+                    activity_id: 'forge.test.start',
+                    agent_path: 'does/not/exist.md',
+                    transitions: [{ to_node_id: 'done' }],
+                },
+                {
+                    node_id: 'done',
+                    type: 'terminal',
+                    name: 'Done',
+                },
+            ],
+        };
+
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/bad-path.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'binding.unresolved_path',
+                    severity: 'error',
+                    path: '/nodes/0/agent_path',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('returns no diagnostics for non-object content', () => {
+        const result = validateWorkflowDomain('not-an-object', {
+            path: '.ai/workflows/invalid.json',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+});

--- a/src/workflows/validateWorkflowDomain.ts
+++ b/src/workflows/validateWorkflowDomain.ts
@@ -1,0 +1,444 @@
+import fs from 'fs';
+import path from 'path';
+import type { WorkflowDiagnostic, WorkflowSchemaValidationResult } from './types';
+
+export const WORKFLOW_GRAPH_VALIDATOR_ID = 'forge.workflow.graph';
+export const WORKFLOW_BINDING_VALIDATOR_ID = 'forge.workflow.binding';
+export const WORKFLOW_DUPLICATE_ID_VALIDATOR_ID = 'forge.workflow.duplicate_id';
+export const WORKFLOW_UNSUPPORTED_VERSION_VALIDATOR_ID = 'forge.workflow.unsupported_version';
+export const WORKFLOW_ORPHAN_NODE_CODE = 'graph.orphan_node';
+
+const SUPPORTED_SCHEMA_VERSION_MAJOR = 1;
+
+const FORGE_CATALOG_VALIDATOR_IDS = new Set([
+    'forge.workflow.schema',
+    'forge.workflow.graph',
+    'forge.workflow.binding',
+    'forge.workflow.duplicate_id',
+    'forge.workflow.unsupported_version',
+    'forge.artifact.declared',
+    'forge.artifact.exists',
+    'forge.artifact.integrity',
+    'forge.artifact.schema',
+    'forge.envelope.schema',
+    'forge.envelope.unsupported_version',
+    'forge.envelope.size',
+    'forge.domain.exit_criteria',
+    'local.forge.refine_issue.exit_criteria',
+]);
+
+export interface WorkflowDomainValidationOptions {
+    path: string;
+    workspaceRoot?: string;
+    discoveredWorkflowIds?: string[];
+}
+
+interface WorkflowNode {
+    node_id?: string;
+    type?: string;
+    activity_id?: string;
+    agent_path?: string;
+    skill_path?: string;
+    validators?: Array<{ validator_id?: string; type?: string; target?: string }>;
+    artifact_ids?: string[];
+    retry_policy?: string;
+    timeout_policy?: string;
+    transitions?: Array<{ to_node_id?: string; condition?: string }>;
+}
+
+function readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    return value as Record<string, unknown>;
+}
+
+function readNodes(content: Record<string, unknown>): WorkflowNode[] {
+    const nodes = content.nodes;
+    if (!Array.isArray(nodes)) {
+        return [];
+    }
+    return nodes.filter((node) => node && typeof node === 'object' && !Array.isArray(node)) as WorkflowNode[];
+}
+
+function parseSemverMajor(version: string): number | undefined {
+    const match = /^(\d+)\./.exec(version.trim());
+    if (!match) {
+        return undefined;
+    }
+    return Number.parseInt(match[1], 10);
+}
+
+function isKnownValidatorId(validatorId: string): boolean {
+    if (FORGE_CATALOG_VALIDATOR_IDS.has(validatorId)) {
+        return true;
+    }
+    return /^local\.[a-z0-9_]+(\.[a-z0-9_]+)*$/i.test(validatorId);
+}
+
+function pathExists(workspaceRoot: string | undefined, repoRelativePath: string): boolean {
+    if (!workspaceRoot) {
+        return true;
+    }
+    return fs.existsSync(path.join(workspaceRoot, repoRelativePath));
+}
+
+function filenameStemFromDefinitionPath(definitionPath: string): string {
+    return path.basename(definitionPath, '.json');
+}
+
+function aggregateValid(diagnostics: WorkflowDiagnostic[]): boolean {
+    return !diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+}
+
+function collectReachableNodeIds(
+    entryNodeId: string,
+    nodesById: Map<string, WorkflowNode>
+): Set<string> {
+    const reachable = new Set<string>();
+    const queue = [entryNodeId];
+
+    while (queue.length > 0) {
+        const currentId = queue.shift();
+        if (!currentId || reachable.has(currentId)) {
+            continue;
+        }
+
+        reachable.add(currentId);
+        const node = nodesById.get(currentId);
+        if (!node?.transitions) {
+            continue;
+        }
+
+        for (const transition of node.transitions) {
+            const targetId = readString(transition.to_node_id);
+            if (targetId && nodesById.has(targetId) && !reachable.has(targetId)) {
+                queue.push(targetId);
+            }
+        }
+    }
+
+    return reachable;
+}
+
+function validateUnsupportedVersion(
+    content: Record<string, unknown>,
+    diagnostics: WorkflowDiagnostic[]
+): void {
+    const schemaVersion = readString(content.schema_version);
+    if (!schemaVersion) {
+        return;
+    }
+
+    const major = parseSemverMajor(schemaVersion);
+    if (major === undefined || major !== SUPPORTED_SCHEMA_VERSION_MAJOR) {
+        diagnostics.push({
+            code: 'forge.workflow.unsupported_version',
+            severity: 'error',
+            path: '/schema_version',
+            message: `unsupported schema_version "${schemaVersion}" (supported major: ${SUPPORTED_SCHEMA_VERSION_MAJOR})`,
+            validator_id: WORKFLOW_UNSUPPORTED_VERSION_VALIDATOR_ID,
+        });
+    }
+}
+
+function validateDuplicateWorkflowId(
+    workflowId: string | undefined,
+    definitionPath: string,
+    discoveredWorkflowIds: string[] | undefined,
+    diagnostics: WorkflowDiagnostic[]
+): void {
+    if (!workflowId || !discoveredWorkflowIds) {
+        return;
+    }
+
+    const duplicateCount = discoveredWorkflowIds.filter((id) => id === workflowId).length;
+    if (duplicateCount > 1) {
+        diagnostics.push({
+            code: 'forge.workflow.duplicate_id',
+            severity: 'error',
+            path: definitionPath,
+            message: `duplicate workflow_id "${workflowId}" across discovered workflow definition files`,
+            validator_id: WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
+        });
+    }
+}
+
+function validateGraph(
+    content: Record<string, unknown>,
+    nodes: WorkflowNode[],
+    diagnostics: WorkflowDiagnostic[]
+): void {
+    const entryNodeId = readString(content.entry_node_id);
+    const nodesById = new Map<string, WorkflowNode>();
+    const nodeIndexById = new Map<string, number>();
+
+    nodes.forEach((node, index) => {
+        const nodeId = readString(node.node_id);
+        if (nodeId) {
+            nodesById.set(nodeId, node);
+            nodeIndexById.set(nodeId, index);
+        }
+    });
+
+    if (entryNodeId && !nodesById.has(entryNodeId)) {
+        diagnostics.push({
+            code: 'graph.missing_entry_node',
+            severity: 'error',
+            path: '/entry_node_id',
+            message: `entry_node_id "${entryNodeId}" does not match any node_id in nodes`,
+            validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+        });
+        return;
+    }
+
+    if (!entryNodeId) {
+        return;
+    }
+
+    nodes.forEach((node, nodeIndex) => {
+        if (!node.transitions) {
+            return;
+        }
+
+        node.transitions.forEach((transition, transitionIndex) => {
+            const targetId = readString(transition.to_node_id);
+            if (!targetId) {
+                return;
+            }
+
+            if (!nodesById.has(targetId)) {
+                diagnostics.push({
+                    code: 'graph.missing_transition_target',
+                    severity: 'error',
+                    path: `/nodes/${nodeIndex}/transitions/${transitionIndex}/to_node_id`,
+                    message: `transition target "${targetId}" does not match any node_id in nodes`,
+                    validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+                });
+            }
+        });
+    });
+
+    const reachable = collectReachableNodeIds(entryNodeId, nodesById);
+    const terminalReachable = [...reachable].some((nodeId) => nodesById.get(nodeId)?.type === 'terminal');
+
+    if (!terminalReachable) {
+        diagnostics.push({
+            code: 'graph.unreachable_terminal',
+            severity: 'error',
+            path: '/entry_node_id',
+            message: 'no terminal node is reachable from entry_node_id',
+            validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+        });
+    }
+
+    for (const [nodeId, nodeIndex] of nodeIndexById) {
+        if (!reachable.has(nodeId)) {
+            diagnostics.push({
+                code: WORKFLOW_ORPHAN_NODE_CODE,
+                severity: 'warning',
+                path: `/nodes/${nodeIndex}`,
+                message: `node "${nodeId}" is not reachable from entry_node_id`,
+                validator_id: WORKFLOW_GRAPH_VALIDATOR_ID,
+            });
+        }
+    }
+}
+
+function validateBindings(
+    content: Record<string, unknown>,
+    nodes: WorkflowNode[],
+    options: WorkflowDomainValidationOptions,
+    diagnostics: WorkflowDiagnostic[]
+): void {
+    const workflowId = readString(content.workflow_id);
+    const filenameStem = filenameStemFromDefinitionPath(options.path);
+
+    if (workflowId && filenameStem !== workflowId) {
+        diagnostics.push({
+            code: 'binding.filename_stem_mismatch',
+            severity: 'error',
+            path: options.path,
+            message: `filename stem "${filenameStem}" must equal workflow_id "${workflowId}"`,
+            validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+        });
+    }
+
+    const artifactIds = new Set<string>();
+    const artifacts = content.artifacts;
+    if (Array.isArray(artifacts)) {
+        for (const artifact of artifacts) {
+            const record = readRecord(artifact);
+            const artifactId = record ? readString(record.artifact_id) : undefined;
+            if (artifactId) {
+                artifactIds.add(artifactId);
+            }
+        }
+    }
+
+    const retryPolicyIds = new Set<string>();
+    const retryPolicies = content.retry_policies;
+    if (Array.isArray(retryPolicies)) {
+        for (const policy of retryPolicies) {
+            const record = readRecord(policy);
+            const policyId = record ? readString(record.policy_id) : undefined;
+            if (policyId) {
+                retryPolicyIds.add(policyId);
+            }
+        }
+    }
+
+    const timeoutPolicyIds = new Set<string>();
+    const timeoutPolicies = content.timeout_policies;
+    if (Array.isArray(timeoutPolicies)) {
+        for (const policy of timeoutPolicies) {
+            const record = readRecord(policy);
+            const policyId = record ? readString(record.policy_id) : undefined;
+            if (policyId) {
+                timeoutPolicyIds.add(policyId);
+            }
+        }
+    }
+
+    nodes.forEach((node, nodeIndex) => {
+        const nodeType = readString(node.type);
+
+        if (nodeType === 'activity') {
+            const activityId = readString(node.activity_id);
+            if (!activityId) {
+                diagnostics.push({
+                    code: 'binding.missing_activity_id',
+                    severity: 'error',
+                    path: `/nodes/${nodeIndex}/activity_id`,
+                    message: 'activity nodes must declare activity_id',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                });
+            }
+
+            const agentPath = readString(node.agent_path);
+            const skillPath = readString(node.skill_path);
+            const bindingCount = Number(Boolean(agentPath)) + Number(Boolean(skillPath));
+
+            if (bindingCount !== 1) {
+                diagnostics.push({
+                    code: 'binding.missing_agent_or_skill_path',
+                    severity: 'error',
+                    path: `/nodes/${nodeIndex}`,
+                    message: 'activity nodes must declare exactly one of agent_path or skill_path',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                });
+            } else {
+                const bindingPath = agentPath ?? skillPath;
+                if (bindingPath && !pathExists(options.workspaceRoot, bindingPath)) {
+                    diagnostics.push({
+                        code: 'binding.unresolved_path',
+                        severity: 'error',
+                        path: agentPath ? `/nodes/${nodeIndex}/agent_path` : `/nodes/${nodeIndex}/skill_path`,
+                        message: `binding path "${bindingPath}" does not resolve in the workspace`,
+                        validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                    });
+                }
+            }
+        }
+
+        if (nodeType === 'validation' && Array.isArray(node.validators)) {
+            node.validators.forEach((validator, validatorIndex) => {
+                const validatorId = readString(validator.validator_id);
+                if (!validatorId) {
+                    return;
+                }
+
+                if (!isKnownValidatorId(validatorId)) {
+                    diagnostics.push({
+                        code: 'binding.unknown_validator_id',
+                        severity: 'error',
+                        path: `/nodes/${nodeIndex}/validators/${validatorIndex}/validator_id`,
+                        message: `validator_id "${validatorId}" is not in the catalog and does not match local.* pattern`,
+                        validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                    });
+                }
+            });
+        }
+
+        if (node.retry_policy) {
+            const retryPolicy = readString(node.retry_policy);
+            if (retryPolicy && !retryPolicyIds.has(retryPolicy)) {
+                diagnostics.push({
+                    code: 'binding.unresolved_retry_policy',
+                    severity: 'error',
+                    path: `/nodes/${nodeIndex}/retry_policy`,
+                    message: `retry_policy "${retryPolicy}" does not match any declared retry_policies entry`,
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                });
+            }
+        }
+
+        if (node.timeout_policy) {
+            const timeoutPolicy = readString(node.timeout_policy);
+            if (timeoutPolicy && !timeoutPolicyIds.has(timeoutPolicy)) {
+                diagnostics.push({
+                    code: 'binding.unresolved_timeout_policy',
+                    severity: 'error',
+                    path: `/nodes/${nodeIndex}/timeout_policy`,
+                    message: `timeout_policy "${timeoutPolicy}" does not match any declared timeout_policies entry`,
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                });
+            }
+        }
+
+        if (Array.isArray(node.artifact_ids)) {
+            node.artifact_ids.forEach((artifactId, artifactIndex) => {
+                if (typeof artifactId !== 'string' || artifactId.length === 0) {
+                    return;
+                }
+
+                if (!artifactIds.has(artifactId)) {
+                    diagnostics.push({
+                        code: 'binding.unresolved_artifact_id',
+                        severity: 'error',
+                        path: `/nodes/${nodeIndex}/artifact_ids/${artifactIndex}`,
+                        message: `artifact_id "${artifactId}" is not declared in workflow artifacts`,
+                        validator_id: 'forge.artifact.declared',
+                    });
+                }
+            });
+        }
+    });
+}
+
+export function validateWorkflowDomain(
+    content: unknown,
+    options: WorkflowDomainValidationOptions
+): WorkflowSchemaValidationResult {
+    const record = readRecord(content);
+    const workflow_id = record ? readString(record.workflow_id) : undefined;
+    const definitionPath = options.path;
+
+    if (!record) {
+        return {
+            valid: true,
+            diagnostics: [],
+            workflow_id,
+            path: definitionPath,
+        };
+    }
+
+    const diagnostics: WorkflowDiagnostic[] = [];
+    const nodes = readNodes(record);
+
+    validateUnsupportedVersion(record, diagnostics);
+    validateDuplicateWorkflowId(workflow_id, definitionPath, options.discoveredWorkflowIds, diagnostics);
+    validateGraph(record, nodes, diagnostics);
+    validateBindings(record, nodes, options, diagnostics);
+
+    return {
+        valid: aggregateValid(diagnostics),
+        diagnostics,
+        workflow_id,
+        path: definitionPath,
+    };
+}

--- a/src/workflows/validateWorkflowForRun.test.ts
+++ b/src/workflows/validateWorkflowForRun.test.ts
@@ -1,0 +1,168 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+    gateWorkflowRunStart,
+    validateWorkflowForRun,
+    WorkflowRunStartBlockedError,
+} from './validateWorkflowForRun';
+import { resetWorkflowSchemaValidatorCacheForTests } from './validateWorkflowSchema';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+const tempDirs: string[] = [];
+
+function readFixture(name: string): unknown {
+    return JSON.parse(fs.readFileSync(path.join(fixturesDir, name), 'utf8'));
+}
+
+function createTempWorkspace(workflows: Record<string, unknown>): string {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-workflow-prerun-'));
+    tempDirs.push(tempDir);
+
+    const workflowsDir = path.join(tempDir, '.ai', 'workflows');
+    fs.mkdirSync(workflowsDir, { recursive: true });
+
+    for (const [filename, content] of Object.entries(workflows)) {
+        fs.writeFileSync(
+            path.join(workflowsDir, filename),
+            `${JSON.stringify(content, null, 2)}\n`,
+            'utf8'
+        );
+    }
+
+    return tempDir;
+}
+
+afterEach(() => {
+    resetWorkflowSchemaValidatorCacheForTests();
+
+    while (tempDirs.length > 0) {
+        const tempDir = tempDirs.pop();
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('validateWorkflowForRun', () => {
+    beforeEach(() => {
+        resetWorkflowSchemaValidatorCacheForTests();
+    });
+
+    it('resolves workflow_id via discovery and validates the definition', () => {
+        const workspaceRoot = createTempWorkspace({
+            'test-minimal.json': readFixture('valid-minimal.json'),
+        });
+
+        const result = validateWorkflowForRun({
+            workspaceRoots: [workspaceRoot],
+            workflowId: 'test-minimal',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.workflow_id).toBe('test-minimal');
+        expect(result.path).toBe('.ai/workflows/test-minimal.json');
+    });
+
+    it('blocks invalid definitions resolved by workflow_id', () => {
+        const workspaceRoot = createTempWorkspace({
+            'broken-transition.json': readFixture('broken-transition.json'),
+        });
+
+        const result = validateWorkflowForRun({
+            workspaceRoots: [workspaceRoot],
+            workflowId: 'broken-transition',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'graph.missing_transition_target',
+                    severity: 'error',
+                }),
+            ])
+        );
+    });
+
+    it('validates by direct definition path', () => {
+        const workspaceRoot = createTempWorkspace({
+            'test-minimal.json': readFixture('valid-minimal.json'),
+            'broken-transition.json': readFixture('broken-transition.json'),
+        });
+
+        const valid = validateWorkflowForRun({
+            workspaceRoots: [workspaceRoot],
+            definitionPath: '.ai/workflows/test-minimal.json',
+        });
+        const invalid = validateWorkflowForRun({
+            workspaceRoots: [workspaceRoot],
+            definitionPath: '.ai/workflows/broken-transition.json',
+        });
+
+        expect(valid.valid).toBe(true);
+        expect(invalid.valid).toBe(false);
+    });
+
+    it('reports not found when workflow_id is missing from discovery', () => {
+        const workspaceRoot = createTempWorkspace({
+            'test-minimal.json': readFixture('valid-minimal.json'),
+        });
+
+        const result = validateWorkflowForRun({
+            workspaceRoots: [workspaceRoot],
+            workflowId: 'missing-workflow',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'forge.workflow.not_found',
+                    severity: 'error',
+                }),
+            ])
+        );
+    });
+});
+
+describe('gateWorkflowRunStart', () => {
+    it('returns the validation result when the definition is valid', () => {
+        const workspaceRoot = createTempWorkspace({
+            'test-minimal.json': readFixture('valid-minimal.json'),
+        });
+
+        const result = gateWorkflowRunStart({
+            workspaceRoots: [workspaceRoot],
+            workflowId: 'test-minimal',
+        });
+
+        expect(result.valid).toBe(true);
+    });
+
+    it('throws WorkflowRunStartBlockedError when validation fails', () => {
+        const workspaceRoot = createTempWorkspace({
+            'missing-binding.json': readFixture('missing-binding.json'),
+        });
+
+        expect(() =>
+            gateWorkflowRunStart({
+                workspaceRoots: [workspaceRoot],
+                workflowId: 'missing-binding',
+            })
+        ).toThrow(WorkflowRunStartBlockedError);
+
+        try {
+            gateWorkflowRunStart({
+                workspaceRoots: [workspaceRoot],
+                workflowId: 'missing-binding',
+            });
+        } catch (error) {
+            expect(error).toBeInstanceOf(WorkflowRunStartBlockedError);
+            const blocked = error as WorkflowRunStartBlockedError;
+            expect(blocked.result.valid).toBe(false);
+            expect(blocked.result.workflow_id).toBe('missing-binding');
+        }
+    });
+});

--- a/src/workflows/validateWorkflowForRun.ts
+++ b/src/workflows/validateWorkflowForRun.ts
@@ -1,0 +1,177 @@
+import fs from 'fs';
+import path from 'path';
+import { discoverWorkflowDefinitions } from './discoverWorkflowDefinitions';
+import {
+    validateWorkflowDefinition,
+    validateWorkflowDefinitionFile,
+} from './validateWorkflowDefinition';
+import type { Diagnostic, ValidationResult } from './types';
+
+export interface ValidateWorkflowForRunOptions {
+    workspaceRoots: string[];
+    workflowId?: string;
+    definitionPath?: string;
+}
+
+export class WorkflowRunStartBlockedError extends Error {
+    readonly result: ValidationResult;
+
+    constructor(result: ValidationResult) {
+        const target = result.workflow_id ?? result.path ?? 'workflow definition';
+        super(`workflow run start blocked: pre-run validation failed for ${target}`);
+        this.name = 'WorkflowRunStartBlockedError';
+        this.result = result;
+    }
+}
+
+function toPosixPath(repoRelativePath: string): string {
+    return repoRelativePath.split(path.sep).join('/');
+}
+
+function resolveWorkspaceRootForRelativePath(
+    workspaceRoots: string[],
+    relativePath: string
+): string | undefined {
+    const posixPath = toPosixPath(relativePath);
+
+    for (const workspaceRoot of workspaceRoots) {
+        const absoluteRoot = path.resolve(workspaceRoot);
+        const candidate = path.join(absoluteRoot, posixPath);
+        if (fs.existsSync(candidate)) {
+            return absoluteRoot;
+        }
+    }
+
+    return undefined;
+}
+
+function notFoundResult(workflowId: string, discoveryDiagnostics: Diagnostic[]): ValidationResult {
+    return {
+        valid: false,
+        diagnostics: [
+            ...discoveryDiagnostics,
+            {
+                code: 'forge.workflow.not_found',
+                severity: 'error',
+                path: '.ai/workflows',
+                message: `workflow_id "${workflowId}" was not found in workspace workflow definitions`,
+                validator_id: 'forge.workflow.binding',
+            },
+        ],
+    };
+}
+
+export function validateWorkflowForRun(options: ValidateWorkflowForRunOptions): ValidationResult {
+    const workspaceRoots = options.workspaceRoots.map((root) => path.resolve(root));
+
+    if (options.definitionPath) {
+        const relativePath = toPosixPath(options.definitionPath);
+        const workspaceRoot =
+            resolveWorkspaceRootForRelativePath(workspaceRoots, relativePath) ?? workspaceRoots[0];
+        const discovery = discoverWorkflowDefinitions(workspaceRoots, { validateSchema: false });
+        const discoveredWorkflowIds = discovery.entries.map((entry) => entry.workflow_id);
+
+        const result = validateWorkflowDefinitionFile(relativePath, {
+            workspaceRoot,
+            discoveredWorkflowIds,
+        });
+
+        return {
+            ...result,
+            diagnostics: [...discovery.diagnostics, ...result.diagnostics],
+            valid:
+                result.valid &&
+                !discovery.diagnostics.some((diagnostic) => diagnostic.severity === 'error'),
+        };
+    }
+
+    const workflowId = options.workflowId;
+    if (!workflowId) {
+        return {
+            valid: false,
+            diagnostics: [
+                {
+                    code: 'forge.workflow.missing_target',
+                    severity: 'error',
+                    path: '.ai/workflows',
+                    message: 'validateWorkflowForRun requires workflowId or definitionPath',
+                    validator_id: 'forge.workflow.binding',
+                },
+            ],
+        };
+    }
+
+    const discovery = discoverWorkflowDefinitions(workspaceRoots, { validateSchema: false });
+    const entry = discovery.entries.find((candidate) => candidate.workflow_id === workflowId);
+    if (!entry) {
+        return notFoundResult(workflowId, discovery.diagnostics);
+    }
+
+    const workspaceRoot = resolveWorkspaceRootForRelativePath(workspaceRoots, entry.path);
+    if (!workspaceRoot) {
+        return {
+            valid: false,
+            diagnostics: [
+                ...discovery.diagnostics,
+                {
+                    code: 'forge.workflow.unresolved_path',
+                    severity: 'error',
+                    path: entry.path,
+                    message: `workflow definition path "${entry.path}" does not resolve in workspace roots`,
+                    validator_id: 'forge.workflow.binding',
+                },
+            ],
+            workflow_id: workflowId,
+            path: entry.path,
+        };
+    }
+
+    const absolutePath = path.join(workspaceRoot, entry.path);
+    let content: unknown;
+    try {
+        content = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'invalid JSON';
+        return {
+            valid: false,
+            diagnostics: [
+                ...discovery.diagnostics,
+                {
+                    code: 'forge.workflow.parse_error',
+                    severity: 'error',
+                    path: entry.path,
+                    message: `failed to parse workflow definition: ${message}`,
+                    validator_id: 'forge.workflow.schema',
+                },
+            ],
+            workflow_id: workflowId,
+            path: entry.path,
+        };
+    }
+
+    const discoveredWorkflowIds = discovery.entries.map((candidate) => candidate.workflow_id);
+    const result = validateWorkflowDefinition(content, {
+        path: entry.path,
+        workspaceRoot,
+        discoveredWorkflowIds,
+    });
+
+    return {
+        ...result,
+        diagnostics: [...discovery.diagnostics, ...result.diagnostics],
+        valid:
+            result.valid &&
+            !discovery.diagnostics.some((diagnostic) => diagnostic.severity === 'error'),
+    };
+}
+
+/**
+ * Pre-run gate invoked before Temporal run creation. Throws when validation fails.
+ */
+export function gateWorkflowRunStart(options: ValidateWorkflowForRunOptions): ValidationResult {
+    const result = validateWorkflowForRun(options);
+    if (!result.valid) {
+        throw new WorkflowRunStartBlockedError(result);
+    }
+    return result;
+}


### PR DESCRIPTION
## Description

Pre-run workflow validation for Forge: schema validation (#29), domain rules (#31), workspace discovery (#30), and orchestration (#32) composed into a single aggregate result suitable for catalog health and Temporal run-start gates.

**Epic scope (#16):**
- `validateWorkflowDefinition` — loads a definition, runs schema then domain validation, merges diagnostics (schema first)
- `validateWorkflowDomain` — graph, binding, duplicate ID, unsupported version, and `forge.artifact.declared` rules
- `validateWorkflowForRun` — resolves `workflow_id` via discovery or accepts a direct path, returns aggregate `{ valid, diagnostics, workflow_id, path }`
- `gateWorkflowRunStart` — throws `WorkflowRunStartBlockedError` when `valid` is false (Temporal client stub hook)
- `src/workflows/index.ts` — public module exports for discovery and run-start consumers
- `preRunValidatorScope` — explicit pre-run validator catalog per `.ai/business_logic/domain_model.md`

Closes #16
Closes #31
Closes #32

## Motivation and Context

Forge must block Temporal run creation when workflow definitions fail pre-run validation. Domain rules (#31) and schema checks (#29) compose through one orchestrator that discovery and run-start code can share.

**Note:** Core implementation landed on `main` via an earlier merge; this branch was recreated from `main` to add the public module index and pre-run scope constants, and to close the parent epic with a clean PR.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`) — 157 tests pass
- [x] Linter passes (`npm run lint`)
- [x] CI green on this PR

Orchestration tests cover schema-only failure, domain-only failure, combined failures (schema diagnostics first), warnings-only (`valid: true`), happy path, workflow_id resolution, direct path validation, run-start gate blocking, and pre-run validator scope.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)