### PR TITLE
External and Cloud Temporal configuration and credentials (#19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,14 @@
       {
         "command": "forge.showRoadmap",
         "title": "Forge: Roadmap"
+      },
+      {
+        "command": "forge.setTemporalApiKey",
+        "title": "Forge: Set Temporal API Key"
+      },
+      {
+        "command": "forge.clearTemporalApiKey",
+        "title": "Forge: Clear Temporal API Key"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,37 @@
           "type": "string",
           "default": "forge-workflows",
           "description": "Default task queue for workflow workers in managed-local mode."
+        },
+        "forge.temporal.external.address": {
+          "type": "string",
+          "default": "",
+          "description": "gRPC endpoint for external Temporal as host:port (required when forge.temporal.mode is external)."
+        },
+        "forge.temporal.external.namespace": {
+          "type": "string",
+          "default": "",
+          "description": "Temporal namespace for external mode (required when forge.temporal.mode is external)."
+        },
+        "forge.temporal.external.taskQueue": {
+          "type": "string",
+          "default": "forge-workflows",
+          "description": "Default task queue for workflow workers connecting to the external Temporal endpoint."
+        },
+        "forge.temporal.external.auth.mode": {
+          "type": "string",
+          "enum": ["apiKey", "tlsServer", "insecure"],
+          "default": "apiKey",
+          "description": "Client authentication mode for external Temporal (apiKey, tlsServer, or insecure loopback only)."
+        },
+        "forge.temporal.external.tls.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use TLS for external Temporal gRPC. Required for Temporal Cloud; disable only with insecure auth on loopback."
+        },
+        "forge.temporal.external.tls.serverName": {
+          "type": "string",
+          "default": "",
+          "description": "Optional TLS SNI / server name override for self-hosted external Temporal clusters."
         }
       }
     }

--- a/src/commands/SetTemporalApiKeyCommand.ts
+++ b/src/commands/SetTemporalApiKeyCommand.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import {
+    clearExternalApiKey,
+    hasStoredExternalApiKey,
+    storeExternalApiKey,
+} from '../temporal/externalCredentials';
+
+export class SetTemporalApiKeyCommand {
+    static async execute(context: vscode.ExtensionContext): Promise<void> {
+        const apiKey = await vscode.window.showInputBox({
+            title: 'Forge: Set Temporal API Key',
+            prompt: 'Enter the API key for your external Temporal endpoint.',
+            password: true,
+            ignoreFocusOut: true,
+            placeHolder: 'Temporal Cloud or API-key-secured cluster key',
+            validateInput: (value) => {
+                if (!value.trim()) {
+                    return 'API key cannot be empty.';
+                }
+                return undefined;
+            },
+        });
+
+        if (apiKey === undefined) {
+            return;
+        }
+
+        await storeExternalApiKey(context.secrets, apiKey);
+        void vscode.window.showInformationMessage(
+            'Forge stored the Temporal API key in VS Code SecretStorage.'
+        );
+    }
+}
+
+export class ClearTemporalApiKeyCommand {
+    static async execute(context: vscode.ExtensionContext): Promise<void> {
+        const hasStoredKey = await hasStoredExternalApiKey(context.secrets);
+        if (!hasStoredKey) {
+            void vscode.window.showInformationMessage(
+                'No Temporal API key is stored in VS Code SecretStorage.'
+            );
+            return;
+        }
+
+        const action = await vscode.window.showWarningMessage(
+            'Clear the stored Temporal API key from VS Code SecretStorage?',
+            { modal: true },
+            'Clear API key'
+        );
+
+        if (action !== 'Clear API key') {
+            return;
+        }
+
+        await clearExternalApiKey(context.secrets);
+        void vscode.window.showInformationMessage('Forge cleared the stored Temporal API key.');
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,17 @@ import * as vscode from 'vscode';
 import { InitializeAgentsCommand } from './commands/InitializeAgentsCommand';
 import { InitializeProjectCommand } from './commands/InitializeProjectCommand';
 import { RoadmapCommand } from './commands/RoadmapCommand';
+import {
+    ClearTemporalApiKeyCommand,
+    SetTemporalApiKeyCommand,
+} from './commands/SetTemporalApiKeyCommand';
 import { SetupCursorCommand, projectForgeAssetsNeedSync } from './commands/SetupCursorCommand';
 import { ForgeChatParticipant } from './chatParticipant';
+import {
+    clearRegisteredStoredApiKeyReader,
+    createStoredApiKeyReader,
+    registerStoredApiKeyReader,
+} from './temporal/externalCredentials';
 import {
     registerTemporalLocalSupervisor,
     shutdownTemporalLocalSupervisor,
@@ -176,6 +185,29 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(roadmapCommand);
 
     registerProjectSyncPrompt(context, outputChannel);
+
+    registerStoredApiKeyReader(createStoredApiKeyReader(context.secrets));
+    context.subscriptions.push({
+        dispose: () => {
+            clearRegisteredStoredApiKeyReader();
+        },
+    });
+
+    const setTemporalApiKeyCommand = vscode.commands.registerCommand(
+        'forge.setTemporalApiKey',
+        async () => {
+            await SetTemporalApiKeyCommand.execute(context);
+        }
+    );
+    context.subscriptions.push(setTemporalApiKeyCommand);
+
+    const clearTemporalApiKeyCommand = vscode.commands.registerCommand(
+        'forge.clearTemporalApiKey',
+        async () => {
+            await ClearTemporalApiKeyCommand.execute(context);
+        }
+    );
+    context.subscriptions.push(clearTemporalApiKeyCommand);
 
     registerTemporalLocalSupervisor(context);
 

--- a/src/temporal/ExternalTemporalSupervisor.test.ts
+++ b/src/temporal/ExternalTemporalSupervisor.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    ExternalReadinessBlockedError,
+    ExternalTemporalSupervisor,
+} from './ExternalTemporalSupervisor';
+import type { ResolvedExternalSettings } from './externalSettings';
+
+const externalSettings: ResolvedExternalSettings = {
+    address: 'temporal.example.com:7233',
+    namespace: 'forge-external',
+    taskQueue: 'forge-workflows',
+    authMode: 'apiKey',
+    tlsEnabled: true,
+    tlsServerName: '',
+};
+
+function createSupervisor(options: {
+    preflightResults: Array<void | Error>;
+    probeResults?: boolean[];
+}) {
+    let preflightIndex = 0;
+    let probeIndex = 0;
+
+    const supervisor = new ExternalTemporalSupervisor(
+        {
+            windowId: 'window-test',
+            resolveSettings: () => externalSettings,
+            resolveApiKey: async () => 'secret-key',
+        },
+        {
+            preflight: async () => {
+                const result = options.preflightResults[preflightIndex];
+                preflightIndex += 1;
+                if (result instanceof Error) {
+                    throw result;
+                }
+            },
+            probeHealth: async () => {
+                const result = options.probeResults?.[probeIndex] ?? true;
+                probeIndex += 1;
+                return result;
+            },
+        }
+    );
+
+    return supervisor;
+}
+
+describe('ExternalTemporalSupervisor', () => {
+    it('starts idle and transitions to ready after preflight succeeds', async () => {
+        const supervisor = createSupervisor({ preflightResults: [undefined] });
+
+        expect(supervisor.getHealthState()).toBe('idle');
+        await supervisor.ensureReady();
+        expect(supervisor.getHealthState()).toBe('ready');
+    });
+
+    it('transitions to connect_failed on auth failure and blocks subsequent runs', async () => {
+        const supervisor = createSupervisor({
+            preflightResults: [new Error('UNAUTHENTICATED: invalid api key')],
+        });
+
+        await expect(supervisor.ensureReady()).rejects.toBeInstanceOf(ExternalReadinessBlockedError);
+        expect(supervisor.getHealthState()).toBe('connect_failed');
+        expect(supervisor.getConnectError()?.remediation).toBe('auth');
+
+        await expect(supervisor.ensureReady()).rejects.toBeInstanceOf(ExternalReadinessBlockedError);
+    });
+
+    it('classifies address failures', async () => {
+        const error = new Error('connect ECONNREFUSED 127.0.0.1:7233') as NodeJS.ErrnoException;
+        error.code = 'ECONNREFUSED';
+        const supervisor = createSupervisor({ preflightResults: [error] });
+
+        await expect(supervisor.ensureReady()).rejects.toBeInstanceOf(ExternalReadinessBlockedError);
+        expect(supervisor.getConnectError()?.remediation).toBe('address');
+    });
+
+    it('transitions to unhealthy when health probes fail after ready', async () => {
+        vi.useFakeTimers();
+        const supervisor = createSupervisor({
+            preflightResults: [undefined],
+            probeResults: [false, false, false],
+        });
+
+        await supervisor.ensureReady();
+        expect(supervisor.getHealthState()).toBe('ready');
+
+        await vi.advanceTimersByTimeAsync(1_600);
+        expect(supervisor.getHealthState()).toBe('unhealthy');
+        vi.useRealTimers();
+    });
+});

--- a/src/temporal/ExternalTemporalSupervisor.ts
+++ b/src/temporal/ExternalTemporalSupervisor.ts
@@ -1,0 +1,225 @@
+import { EventEmitter } from 'events';
+import { classifyExternalConnectFailure } from './externalConnectFailure';
+import { probeExternalTemporalHealth, probeExternalTemporalPreflight } from './healthProbe';
+import { formatSafeForLog } from './secretRedaction';
+import type {
+    ExternalConnectError,
+    ExternalPreflightProber,
+    ExternalHealthProber,
+    ExternalTemporalHealthState,
+    ExternalTemporalSupervisorConfig,
+} from './types';
+
+export class ExternalReadinessBlockedError extends Error {
+    readonly remediation: ExternalConnectError['remediation'];
+    readonly healthState: ExternalTemporalHealthState;
+
+    constructor(connectError: ExternalConnectError, healthState: ExternalTemporalHealthState) {
+        super(connectError.message);
+        this.name = 'ExternalReadinessBlockedError';
+        this.remediation = connectError.remediation;
+        this.healthState = healthState;
+    }
+}
+
+const HEALTH_PROBE_INTERVAL_MS = 500;
+const UNHEALTHY_PROBE_THRESHOLD = 3;
+
+export interface ExternalTemporalSupervisorOptions {
+    preflight?: ExternalPreflightProber;
+    probeHealth?: ExternalHealthProber;
+    log?: (line: string) => void;
+}
+
+export class ExternalTemporalSupervisor {
+    private readonly emitter = new EventEmitter();
+    private readonly preflight: ExternalPreflightProber;
+    private readonly probeHealth: ExternalHealthProber;
+    private readonly log: (line: string) => void;
+
+    private state: ExternalTemporalHealthState = 'idle';
+    private connectError: ExternalConnectError | undefined;
+    private preflightPromise: Promise<void> | undefined;
+    private consecutiveProbeFailures = 0;
+    private healthMonitorTimer: NodeJS.Timeout | undefined;
+    private insecureWarningLogged = false;
+
+    constructor(
+        private readonly config: ExternalTemporalSupervisorConfig,
+        options: ExternalTemporalSupervisorOptions = {}
+    ) {
+        this.preflight = options.preflight ?? probeExternalTemporalPreflight;
+        this.probeHealth = options.probeHealth ?? probeExternalTemporalHealth;
+        this.log = options.log ?? (() => undefined);
+    }
+
+    getHealthState(): ExternalTemporalHealthState {
+        return this.state;
+    }
+
+    getConnectError(): ExternalConnectError | undefined {
+        return this.connectError;
+    }
+
+    onStateChange(listener: (state: ExternalTemporalHealthState) => void): () => void {
+        this.emitter.on('state', listener);
+        return () => {
+            this.emitter.off('state', listener);
+        };
+    }
+
+    async ensureReady(): Promise<void> {
+        if (this.state === 'ready') {
+            return;
+        }
+
+        if (this.state === 'connect_failed') {
+            throw new ExternalReadinessBlockedError(
+                this.connectError ?? {
+                    remediation: 'config',
+                    message: 'External Temporal connection failed.',
+                },
+                this.state
+            );
+        }
+
+        if (!this.preflightPromise) {
+            this.preflightPromise = this.runPreflight();
+        }
+
+        try {
+            await this.preflightPromise;
+        } catch (error) {
+            if (error instanceof ExternalReadinessBlockedError) {
+                throw error;
+            }
+            throw error;
+        }
+    }
+
+    async stop(): Promise<void> {
+        this.clearHealthMonitor();
+        this.preflightPromise = undefined;
+        this.consecutiveProbeFailures = 0;
+        this.insecureWarningLogged = false;
+
+        if (this.state !== 'connect_failed') {
+            this.transitionTo('idle');
+        }
+    }
+
+    private async runPreflight(): Promise<void> {
+        this.connectError = undefined;
+        this.consecutiveProbeFailures = 0;
+        this.transitionTo('connecting');
+
+        const settings = this.config.resolveSettings();
+        const apiKey = await this.config.resolveApiKey();
+
+        this.logExternalState('connecting', settings, apiKey);
+
+        if (settings.authMode === 'insecure' && !this.insecureWarningLogged) {
+            this.insecureWarningLogged = true;
+            this.log(
+                `[forge.temporal.external] insecure_mode address=${settings.address ?? 'unknown'} authMode=${settings.authMode}`
+            );
+        }
+
+        try {
+            await this.preflight({ settings, apiKey });
+            this.transitionTo('ready');
+            this.logExternalState('ready', settings, apiKey);
+            this.startHealthMonitor(settings, apiKey);
+        } catch (error) {
+            this.failConnect(error, settings, apiKey);
+            throw new ExternalReadinessBlockedError(this.connectError!, this.state);
+        }
+    }
+
+    private startHealthMonitor(
+        settings: ReturnType<ExternalTemporalSupervisorConfig['resolveSettings']>,
+        apiKey: string | undefined
+    ): void {
+        this.clearHealthMonitor();
+        this.healthMonitorTimer = setInterval(() => {
+            void this.runHealthMonitorTick(settings, apiKey);
+        }, HEALTH_PROBE_INTERVAL_MS);
+    }
+
+    private async runHealthMonitorTick(
+        settings: ReturnType<ExternalTemporalSupervisorConfig['resolveSettings']>,
+        apiKey: string | undefined
+    ): Promise<void> {
+        if (this.state !== 'ready' && this.state !== 'unhealthy' && this.state !== 'disconnected') {
+            return;
+        }
+
+        const healthy = await this.probeHealth({ settings, apiKey });
+
+        if (healthy) {
+            this.consecutiveProbeFailures = 0;
+            if (this.state === 'unhealthy' || this.state === 'disconnected') {
+                this.transitionTo('ready');
+                this.logExternalState('ready', settings, apiKey);
+            }
+            return;
+        }
+
+        this.consecutiveProbeFailures += 1;
+        if (this.consecutiveProbeFailures >= UNHEALTHY_PROBE_THRESHOLD) {
+            const nextState: ExternalTemporalHealthState =
+                this.state === 'ready' ? 'unhealthy' : 'disconnected';
+            if (this.state !== nextState) {
+                this.transitionTo(nextState);
+                this.logExternalState(nextState, settings, apiKey);
+            }
+        }
+    }
+
+    private failConnect(
+        error: unknown,
+        settings: ReturnType<ExternalTemporalSupervisorConfig['resolveSettings']>,
+        apiKey: string | undefined
+    ): void {
+        const normalized = error instanceof Error ? error : new Error(String(error));
+        const classified = classifyExternalConnectFailure(normalized);
+        this.connectError = {
+            remediation: classified.remediation,
+            message: classified.message,
+            probeErrorCode: classified.probeErrorCode,
+        };
+        this.clearHealthMonitor();
+        this.transitionTo('connect_failed');
+        this.log(
+            formatSafeForLog(
+                `[forge.temporal.external] connect_failed windowId=${this.config.windowId} address=${settings.address ?? 'unknown'} namespace=${settings.namespace ?? 'unknown'} authMode=${settings.authMode} tlsEnabled=${settings.tlsEnabled} remediation=${classified.remediation} probeErrorCode=${classified.probeErrorCode ?? 'none'} message=${normalized.message}`,
+                { knownSecrets: apiKey ? [apiKey] : [] }
+            )
+        );
+    }
+
+    private logExternalState(
+        state: ExternalTemporalHealthState,
+        settings: ReturnType<ExternalTemporalSupervisorConfig['resolveSettings']>,
+        apiKey: string | undefined
+    ): void {
+        this.log(
+            `[forge.temporal.external] state=${state} windowId=${this.config.windowId} address=${settings.address ?? 'unknown'} namespace=${settings.namespace ?? 'unknown'} authMode=${settings.authMode} tlsEnabled=${settings.tlsEnabled}`
+        );
+    }
+
+    private clearHealthMonitor(): void {
+        if (this.healthMonitorTimer) {
+            clearInterval(this.healthMonitorTimer);
+            this.healthMonitorTimer = undefined;
+        }
+    }
+
+    private transitionTo(next: ExternalTemporalHealthState): void {
+        if (this.state === next) {
+            return;
+        }
+        this.state = next;
+        this.emitter.emit('state', next);
+    }
+}

--- a/src/temporal/externalConnectFailure.test.ts
+++ b/src/temporal/externalConnectFailure.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { classifyExternalConnectFailure } from './externalConnectFailure';
+
+describe('classifyExternalConnectFailure', () => {
+    it('classifies authentication failures', () => {
+        expect(
+            classifyExternalConnectFailure(new Error('UNAUTHENTICATED: invalid api key')).remediation
+        ).toBe('auth');
+    });
+
+    it('classifies TLS failures', () => {
+        expect(
+            classifyExternalConnectFailure(new Error('TLS handshake failed: certificate verify failed'))
+                .remediation
+        ).toBe('tls');
+    });
+
+    it('classifies address failures', () => {
+        const error = new Error('connect ECONNREFUSED 127.0.0.1:7233') as NodeJS.ErrnoException;
+        error.code = 'ECONNREFUSED';
+        expect(classifyExternalConnectFailure(error).remediation).toBe('address');
+    });
+
+    it('falls back to config remediation', () => {
+        expect(classifyExternalConnectFailure(new Error('unexpected failure')).remediation).toBe(
+            'config'
+        );
+    });
+});

--- a/src/temporal/externalConnectFailure.ts
+++ b/src/temporal/externalConnectFailure.ts
@@ -1,0 +1,90 @@
+import type { ExternalConnectFailureRemediation } from './types';
+
+export interface ClassifiedExternalConnectFailure {
+    remediation: ExternalConnectFailureRemediation;
+    message: string;
+    probeErrorCode?: string;
+}
+
+const AUTH_PATTERNS = [
+    /unauthenticated/i,
+    /permission denied/i,
+    /authentication failed/i,
+    /invalid api key/i,
+    /401/,
+    /403/,
+    /UNAUTHENTICATED/,
+    /PERMISSION_DENIED/,
+];
+
+const TLS_PATTERNS = [
+    /certificate/i,
+    /\btls\b/i,
+    /\bssl\b/i,
+    /handshake/i,
+    /x509/i,
+    /CERT_/,
+];
+
+const ADDRESS_PATTERNS = [
+    /ECONNREFUSED/i,
+    /ENOTFOUND/i,
+    /ETIMEDOUT/i,
+    /EHOSTUNREACH/i,
+    /UNAVAILABLE/i,
+    /unreachable/i,
+    /connect ECONNREFUSED/i,
+    /network/i,
+    /connection refused/i,
+];
+
+function extractProbeErrorCode(error: Error): string | undefined {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (typeof code === 'string' && code.length > 0) {
+        return code;
+    }
+
+    const match = error.message.match(/\b([A-Z_]{3,})\b/);
+    return match?.[1];
+}
+
+export function classifyExternalConnectFailure(error: Error): ClassifiedExternalConnectFailure {
+    const message = error.message ?? String(error);
+    const probeErrorCode = extractProbeErrorCode(error);
+
+    for (const pattern of AUTH_PATTERNS) {
+        if (pattern.test(message)) {
+            return {
+                remediation: 'auth',
+                message: 'External Temporal authentication failed.',
+                probeErrorCode,
+            };
+        }
+    }
+
+    for (const pattern of TLS_PATTERNS) {
+        if (pattern.test(message)) {
+            return {
+                remediation: 'tls',
+                message: 'External Temporal TLS handshake failed.',
+                probeErrorCode,
+            };
+        }
+    }
+
+    for (const pattern of ADDRESS_PATTERNS) {
+        if (pattern.test(message)) {
+            return {
+                remediation: 'address',
+                message: 'External Temporal endpoint is unreachable.',
+                probeErrorCode,
+            };
+        }
+    }
+
+    return {
+        remediation: 'config',
+        message: 'External Temporal connection failed.',
+        probeErrorCode,
+    };
+}

--- a/src/temporal/externalConnection.test.ts
+++ b/src/temporal/externalConnection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildExternalConnectionOptions } from './externalConnection';
+import type { ResolvedExternalSettings } from './externalSettings';
+
+function externalSettings(
+    overrides: Partial<ResolvedExternalSettings> = {}
+): ResolvedExternalSettings {
+    return {
+        address: 'my-ns.a1b2c.tmprl.cloud:7233',
+        namespace: 'my-ns.a1b2c',
+        taskQueue: 'forge-workflows',
+        authMode: 'apiKey',
+        tlsEnabled: true,
+        tlsServerName: '',
+        ...overrides,
+    };
+}
+
+describe('externalConnection', () => {
+    it('includes apiKey when auth mode is apiKey', () => {
+        expect(
+            buildExternalConnectionOptions(externalSettings(), 'secret-api-key')
+        ).toEqual({
+            address: 'my-ns.a1b2c.tmprl.cloud:7233',
+            tls: true,
+            apiKey: 'secret-api-key',
+        });
+    });
+
+    it('omits apiKey for tlsServer mode', () => {
+        expect(
+            buildExternalConnectionOptions(
+                externalSettings({ authMode: 'tlsServer' }),
+                'secret-api-key'
+            )
+        ).toEqual({
+            address: 'my-ns.a1b2c.tmprl.cloud:7233',
+            tls: true,
+        });
+    });
+
+    it('disables TLS for insecure loopback mode', () => {
+        expect(
+            buildExternalConnectionOptions(
+                externalSettings({
+                    authMode: 'insecure',
+                    tlsEnabled: false,
+                    address: '127.0.0.1:7233',
+                }),
+                undefined
+            )
+        ).toEqual({
+            address: '127.0.0.1:7233',
+            tls: false,
+        });
+    });
+
+    it('applies TLS server name override when configured', () => {
+        expect(
+            buildExternalConnectionOptions(
+                externalSettings({ tlsServerName: 'temporal.internal' }),
+                'secret-api-key'
+            )
+        ).toEqual({
+            address: 'my-ns.a1b2c.tmprl.cloud:7233',
+            tls: {
+                serverNameOverride: 'temporal.internal',
+            },
+            apiKey: 'secret-api-key',
+        });
+    });
+});

--- a/src/temporal/externalConnection.ts
+++ b/src/temporal/externalConnection.ts
@@ -1,0 +1,29 @@
+import type { ConnectionOptions } from '@temporalio/client';
+import type { ResolvedExternalSettings } from './externalSettings';
+
+export function buildExternalConnectionOptions(
+    settings: ResolvedExternalSettings,
+    apiKey: string | undefined
+): ConnectionOptions {
+    const options: ConnectionOptions = {};
+
+    if (settings.address) {
+        options.address = settings.address;
+    }
+
+    if (settings.authMode === 'insecure' || !settings.tlsEnabled) {
+        options.tls = false;
+    } else if (settings.tlsServerName) {
+        options.tls = {
+            serverNameOverride: settings.tlsServerName,
+        };
+    } else {
+        options.tls = true;
+    }
+
+    if (settings.authMode === 'apiKey' && apiKey) {
+        options.apiKey = apiKey;
+    }
+
+    return options;
+}

--- a/src/temporal/externalCredentials.test.ts
+++ b/src/temporal/externalCredentials.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EXTERNAL_API_KEY_SECRET_KEY } from './externalSettings';
+import {
+    EXTERNAL_CLIENT_CERT_SECRET_KEY,
+    EXTERNAL_CLIENT_KEY_SECRET_KEY,
+    RESERVED_EXTERNAL_SECRET_KEYS,
+    clearExternalApiKey,
+    clearRegisteredStoredApiKeyReader,
+    createStoredApiKeyReader,
+    getRegisteredStoredApiKeyReader,
+    hasStoredExternalApiKey,
+    registerStoredApiKeyReader,
+    storeExternalApiKey,
+} from './externalCredentials';
+
+describe('externalCredentials', () => {
+    afterEach(() => {
+        clearRegisteredStoredApiKeyReader();
+    });
+
+    it('reserves future mTLS secret key names', () => {
+        expect(RESERVED_EXTERNAL_SECRET_KEYS).toEqual([
+            EXTERNAL_API_KEY_SECRET_KEY,
+            EXTERNAL_CLIENT_CERT_SECRET_KEY,
+            EXTERNAL_CLIENT_KEY_SECRET_KEY,
+        ]);
+    });
+
+    it('stores and reads API keys from SecretStorage', async () => {
+        const storage = new Map<string, string>();
+        const secrets = {
+            get: vi.fn(async (key: string) => storage.get(key)),
+            store: vi.fn(async (key: string, value: string) => {
+                storage.set(key, value);
+            }),
+            delete: vi.fn(async (key: string) => {
+                storage.delete(key);
+            }),
+            onDidChange: vi.fn(),
+        };
+
+        await storeExternalApiKey(secrets, '  stored-key  ');
+        expect(secrets.store).toHaveBeenCalledWith(
+            EXTERNAL_API_KEY_SECRET_KEY,
+            'stored-key'
+        );
+
+        const reader = createStoredApiKeyReader(secrets);
+        await expect(reader()).resolves.toBe('stored-key');
+        await expect(hasStoredExternalApiKey(secrets)).resolves.toBe(true);
+
+        await clearExternalApiKey(secrets);
+        await expect(reader()).resolves.toBeUndefined();
+        await expect(hasStoredExternalApiKey(secrets)).resolves.toBe(false);
+    });
+
+    it('registers a default SecretStorage reader for validation', async () => {
+        const reader = vi.fn(async () => 'registered-key');
+        registerStoredApiKeyReader(reader);
+
+        await expect(getRegisteredStoredApiKeyReader()?.()).resolves.toBe('registered-key');
+    });
+});

--- a/src/temporal/externalCredentials.ts
+++ b/src/temporal/externalCredentials.ts
@@ -1,0 +1,54 @@
+import type * as vscode from 'vscode';
+import { EXTERNAL_API_KEY_SECRET_KEY } from './externalSettings';
+
+export const EXTERNAL_CLIENT_CERT_SECRET_KEY = 'forge.temporal.external.clientCert';
+export const EXTERNAL_CLIENT_KEY_SECRET_KEY = 'forge.temporal.external.clientKey';
+
+export const RESERVED_EXTERNAL_SECRET_KEYS = [
+    EXTERNAL_API_KEY_SECRET_KEY,
+    EXTERNAL_CLIENT_CERT_SECRET_KEY,
+    EXTERNAL_CLIENT_KEY_SECRET_KEY,
+] as const;
+
+export type StoredApiKeyReader = () => Promise<string | undefined>;
+
+export function createStoredApiKeyReader(
+    secrets: vscode.SecretStorage
+): StoredApiKeyReader {
+    return async () => {
+        const stored = await secrets.get(EXTERNAL_API_KEY_SECRET_KEY);
+        return stored?.trim() || undefined;
+    };
+}
+
+export async function storeExternalApiKey(
+    secrets: vscode.SecretStorage,
+    apiKey: string
+): Promise<void> {
+    await secrets.store(EXTERNAL_API_KEY_SECRET_KEY, apiKey.trim());
+}
+
+export async function clearExternalApiKey(secrets: vscode.SecretStorage): Promise<void> {
+    await secrets.delete(EXTERNAL_API_KEY_SECRET_KEY);
+}
+
+export async function hasStoredExternalApiKey(
+    secrets: vscode.SecretStorage
+): Promise<boolean> {
+    const stored = await secrets.get(EXTERNAL_API_KEY_SECRET_KEY);
+    return Boolean(stored?.trim());
+}
+
+let registeredStoredApiKeyReader: StoredApiKeyReader | undefined;
+
+export function registerStoredApiKeyReader(reader: StoredApiKeyReader): void {
+    registeredStoredApiKeyReader = reader;
+}
+
+export function getRegisteredStoredApiKeyReader(): StoredApiKeyReader | undefined {
+    return registeredStoredApiKeyReader;
+}
+
+export function clearRegisteredStoredApiKeyReader(): void {
+    registeredStoredApiKeyReader = undefined;
+}

--- a/src/temporal/externalSettings.test.ts
+++ b/src/temporal/externalSettings.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import {
+    resolveExternalApiKey,
+    resolveExternalAuthMode,
+    resolveExternalSettings,
+} from './externalSettings';
+
+describe('externalSettings', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.restoreAllMocks();
+    });
+
+    it('resolves external settings from workspace values', () => {
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockImplementation((section?: string) => {
+            if (section === 'forge.temporal.external') {
+                return {
+                    inspect: (key: string) => {
+                        switch (key) {
+                            case 'address':
+                                return { workspaceValue: 'my-ns.a1b2c.tmprl.cloud:7233' };
+                            case 'namespace':
+                                return { workspaceValue: 'my-ns.a1b2c' };
+                            case 'taskQueue':
+                                return { workspaceValue: 'custom-queue' };
+                            case 'auth.mode':
+                                return { workspaceValue: 'tlsServer' };
+                            case 'tls.enabled':
+                                return { workspaceValue: false };
+                            case 'tls.serverName':
+                                return { workspaceValue: 'temporal.internal' };
+                            default:
+                                return undefined;
+                        }
+                    },
+                } as vscode.WorkspaceConfiguration;
+            }
+            return {} as vscode.WorkspaceConfiguration;
+        });
+
+        expect(resolveExternalSettings()).toEqual({
+            address: 'my-ns.a1b2c.tmprl.cloud:7233',
+            namespace: 'my-ns.a1b2c',
+            taskQueue: 'custom-queue',
+            authMode: 'tlsServer',
+            tlsEnabled: false,
+            tlsServerName: 'temporal.internal',
+        });
+    });
+
+    it('prefers workspace settings over environment variables', () => {
+        process.env.FORGE_TEMPORAL_EXTERNAL_NAMESPACE = 'env-ns';
+        process.env.FORGE_TEMPORAL_EXTERNAL_ADDRESS = 'env-host:7233';
+
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockImplementation((section?: string) => {
+            if (section === 'forge.temporal.external') {
+                return {
+                    inspect: (key: string) => {
+                        if (key === 'namespace') {
+                            return { workspaceValue: 'workspace-ns' };
+                        }
+                        if (key === 'address') {
+                            return { workspaceValue: 'workspace-host:7233' };
+                        }
+                        return undefined;
+                    },
+                } as vscode.WorkspaceConfiguration;
+            }
+            return {} as vscode.WorkspaceConfiguration;
+        });
+
+        const resolved = resolveExternalSettings();
+        expect(resolved.namespace).toBe('workspace-ns');
+        expect(resolved.address).toBe('workspace-host:7233');
+    });
+
+    it('falls back to environment variables when settings are unset', () => {
+        process.env.FORGE_TEMPORAL_EXTERNAL_NAMESPACE = 'env-ns';
+        process.env.FORGE_TEMPORAL_EXTERNAL_ADDRESS = 'env-host:7233';
+        process.env.FORGE_TEMPORAL_EXTERNAL_AUTH_MODE = 'insecure';
+        process.env.FORGE_TEMPORAL_EXTERNAL_TLS_ENABLED = 'false';
+
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockImplementation((section?: string) => {
+            if (section === 'forge.temporal.external') {
+                return {
+                    inspect: () => undefined,
+                } as vscode.WorkspaceConfiguration;
+            }
+            return {} as vscode.WorkspaceConfiguration;
+        });
+
+        const resolved = resolveExternalSettings();
+        expect(resolved.namespace).toBe('env-ns');
+        expect(resolved.address).toBe('env-host:7233');
+        expect(resolved.authMode).toBe('insecure');
+        expect(resolved.tlsEnabled).toBe(false);
+        expect(resolved.taskQueue).toBe('forge-workflows');
+    });
+
+    it('normalizes unknown auth modes to apiKey', () => {
+        expect(resolveExternalAuthMode('unknown')).toBe('apiKey');
+        expect(resolveExternalAuthMode('apiKey')).toBe('apiKey');
+    });
+
+    it('prefers environment API key over SecretStorage', async () => {
+        process.env.FORGE_TEMPORAL_EXTERNAL_API_KEY = 'env-key';
+
+        const stored = vi.fn(async () => 'stored-key');
+        await expect(resolveExternalApiKey(stored)).resolves.toBe('env-key');
+        expect(stored).not.toHaveBeenCalled();
+    });
+
+    it('falls back to SecretStorage when env API key is unset', async () => {
+        delete process.env.FORGE_TEMPORAL_EXTERNAL_API_KEY;
+
+        const stored = vi.fn(async () => 'stored-key');
+        await expect(resolveExternalApiKey(stored)).resolves.toBe('stored-key');
+    });
+});

--- a/src/temporal/externalSettings.ts
+++ b/src/temporal/externalSettings.ts
@@ -1,0 +1,92 @@
+import * as vscode from 'vscode';
+import {
+    resolveBooleanSetting,
+    resolveOptionalStringSetting,
+    resolveStringSetting,
+} from './settingPrecedence';
+
+export type ExternalAuthMode = 'apiKey' | 'tlsServer' | 'insecure';
+
+const DEFAULT_TASK_QUEUE = 'forge-workflows';
+const DEFAULT_AUTH_MODE: ExternalAuthMode = 'apiKey';
+const DEFAULT_TLS_ENABLED = true;
+
+export const EXTERNAL_API_KEY_SECRET_KEY = 'forge.temporal.external.apiKey';
+
+export interface ResolvedExternalSettings {
+    address: string | undefined;
+    namespace: string | undefined;
+    taskQueue: string;
+    authMode: ExternalAuthMode;
+    tlsEnabled: boolean;
+    tlsServerName: string;
+}
+
+export function resolveExternalAuthMode(raw: string): ExternalAuthMode {
+    if (raw === 'tlsServer' || raw === 'insecure') {
+        return raw;
+    }
+    return 'apiKey';
+}
+
+export function resolveExternalSettings(): ResolvedExternalSettings {
+    const config = vscode.workspace.getConfiguration('forge.temporal.external');
+
+    const address = resolveOptionalStringSetting(
+        config.inspect<string>('address'),
+        'FORGE_TEMPORAL_EXTERNAL_ADDRESS'
+    );
+    const namespace = resolveOptionalStringSetting(
+        config.inspect<string>('namespace'),
+        'FORGE_TEMPORAL_EXTERNAL_NAMESPACE'
+    );
+    const taskQueue = resolveStringSetting(
+        config.inspect<string>('taskQueue'),
+        'FORGE_TEMPORAL_EXTERNAL_TASK_QUEUE',
+        DEFAULT_TASK_QUEUE
+    );
+    const authMode = resolveExternalAuthMode(
+        resolveStringSetting(
+            config.inspect<string>('auth.mode'),
+            'FORGE_TEMPORAL_EXTERNAL_AUTH_MODE',
+            DEFAULT_AUTH_MODE
+        )
+    );
+    const tlsEnabled = resolveBooleanSetting(
+        config.inspect<boolean>('tls.enabled'),
+        'FORGE_TEMPORAL_EXTERNAL_TLS_ENABLED',
+        DEFAULT_TLS_ENABLED
+    );
+    const tlsServerName = resolveStringSetting(
+        config.inspect<string>('tls.serverName'),
+        'FORGE_TEMPORAL_EXTERNAL_TLS_SERVER_NAME',
+        ''
+    );
+
+    return {
+        address,
+        namespace,
+        taskQueue,
+        authMode,
+        tlsEnabled,
+        tlsServerName,
+    };
+}
+
+export async function resolveExternalApiKey(
+    getStoredApiKey?: () => Promise<string | undefined>
+): Promise<string | undefined> {
+    const envKey = process.env.FORGE_TEMPORAL_EXTERNAL_API_KEY?.trim();
+    if (envKey) {
+        return envKey;
+    }
+
+    if (getStoredApiKey) {
+        const stored = await getStoredApiKey();
+        if (stored?.trim()) {
+            return stored.trim();
+        }
+    }
+
+    return undefined;
+}

--- a/src/temporal/healthProbe.ts
+++ b/src/temporal/healthProbe.ts
@@ -1,4 +1,6 @@
 import { Connection } from '@temporalio/client';
+import { buildExternalConnectionOptions } from './externalConnection';
+import type { ResolvedExternalSettings } from './externalSettings';
 
 export async function probeManagedLocalTemporalHealth(options: {
     address: string;
@@ -15,5 +17,43 @@ export async function probeManagedLocalTemporalHealth(options: {
         return false;
     } finally {
         await connection?.close().catch(() => undefined);
+    }
+}
+
+export async function probeExternalTemporalPreflight(options: {
+    settings: ResolvedExternalSettings;
+    apiKey: string | undefined;
+}): Promise<void> {
+    const { settings, apiKey } = options;
+    if (!settings.address || !settings.namespace) {
+        throw new Error('External Temporal address and namespace are required.');
+    }
+
+    const connectionOptions = buildExternalConnectionOptions(settings, apiKey);
+    let connection: Connection | undefined;
+    try {
+        connection = await Connection.connect(connectionOptions);
+        await connection.workflowService.getSystemInfo({});
+        await connection.workflowService.describeNamespace({
+            namespace: settings.namespace,
+        });
+        await connection.workflowService.describeTaskQueue({
+            namespace: settings.namespace,
+            taskQueue: { name: settings.taskQueue },
+        });
+    } finally {
+        await connection?.close().catch(() => undefined);
+    }
+}
+
+export async function probeExternalTemporalHealth(options: {
+    settings: ResolvedExternalSettings;
+    apiKey: string | undefined;
+}): Promise<boolean> {
+    try {
+        await probeExternalTemporalPreflight(options);
+        return true;
+    } catch {
+        return false;
     }
 }

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -10,6 +10,21 @@ export {
 } from './managedLocalSettings';
 export type { ResolvedManagedLocalSettings, TemporalMode } from './managedLocalSettings';
 export {
+    EXTERNAL_API_KEY_SECRET_KEY,
+    resolveExternalApiKey,
+    resolveExternalAuthMode,
+    resolveExternalSettings,
+} from './externalSettings';
+export type { ExternalAuthMode, ResolvedExternalSettings } from './externalSettings';
+export {
+    TEMPORAL_CONFIGURATION_VALIDATOR_ID,
+    getTemporalConfigurationErrors,
+    isLoopbackHost,
+    parseAddressHost,
+    validateTemporalConfiguration,
+} from './temporalConfigurationValidation';
+export type { TemporalConfigurationValidationOptions } from './temporalConfigurationValidation';
+export {
     TEMPORAL_READINESS_VALIDATOR_ID,
     TemporalConfigurationInvalidError,
     gateTemporalReadiness,

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -3,6 +3,10 @@ export {
     TemporalReadinessBlockedError,
 } from './TemporalLocalSupervisor';
 export {
+    ExternalTemporalSupervisor,
+    ExternalReadinessBlockedError,
+} from './ExternalTemporalSupervisor';
+export {
     computeDefaultPersistencePath,
     ensurePersistenceDirectory,
     resolveManagedLocalSettings,
@@ -56,8 +60,14 @@ export {
     resolveManagedLocalDevServerEntry,
 } from './devServerLaunch';
 export { classifyStartFailure } from './failureClassification';
+export { classifyExternalConnectFailure } from './externalConnectFailure';
 export {
     formatManagedLocalStatusBarLabel,
+    formatExternalConnectFailedNotification,
+    formatExternalReadyNotification,
+    formatExternalStatusBarLabel,
+    formatExternalStatusBarTooltip,
+    formatInsecureModeWarning,
     formatPersistencePathForDisplay,
     formatReadyNotification,
     formatStartFailedNotification,
@@ -67,10 +77,16 @@ export {
     TEMPORAL_OUTPUT_CHANNEL_NAME,
     createTemporalOutputChannel,
     notifyWorkflowBlockedByTemporal,
+    registerExternalTemporalHealthSurfaces,
     registerManagedLocalTemporalHealthSurfaces,
 } from './temporalHealthSurfaces';
-export { probeManagedLocalTemporalHealth } from './healthProbe';
 export {
+    probeExternalTemporalHealth,
+    probeExternalTemporalPreflight,
+    probeManagedLocalTemporalHealth,
+} from './healthProbe';
+export {
+    getExternalTemporalSupervisor,
     getTemporalLocalSupervisor,
     registerTemporalLocalSupervisor,
     shutdownTemporalLocalSupervisor,
@@ -78,6 +94,12 @@ export {
 export type {
     ChildProcessSpawnOptions,
     ChildProcessSpawner,
+    ExternalConnectError,
+    ExternalConnectFailureRemediation,
+    ExternalHealthProber,
+    ExternalPreflightProber,
+    ExternalTemporalHealthState,
+    ExternalTemporalSupervisorConfig,
     HealthProber,
     ManagedLocalHealthState,
     ManagedLocalStartError,

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -17,6 +17,25 @@ export {
 } from './externalSettings';
 export type { ExternalAuthMode, ResolvedExternalSettings } from './externalSettings';
 export {
+    EXTERNAL_CLIENT_CERT_SECRET_KEY,
+    EXTERNAL_CLIENT_KEY_SECRET_KEY,
+    RESERVED_EXTERNAL_SECRET_KEYS,
+    clearExternalApiKey,
+    clearRegisteredStoredApiKeyReader,
+    createStoredApiKeyReader,
+    getRegisteredStoredApiKeyReader,
+    hasStoredExternalApiKey,
+    registerStoredApiKeyReader,
+    storeExternalApiKey,
+} from './externalCredentials';
+export type { StoredApiKeyReader } from './externalCredentials';
+export { buildExternalConnectionOptions } from './externalConnection';
+export {
+    formatSafeForLog,
+    redactAuthorizationMaterial,
+    redactKnownSecrets,
+} from './secretRedaction';
+export {
     TEMPORAL_CONFIGURATION_VALIDATOR_ID,
     getTemporalConfigurationErrors,
     isLoopbackHost,

--- a/src/temporal/secretRedaction.test.ts
+++ b/src/temporal/secretRedaction.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatSafeForLog,
+    redactAuthorizationMaterial,
+    redactKnownSecrets,
+} from './secretRedaction';
+
+describe('secretRedaction', () => {
+    it('redacts Authorization headers and bearer tokens', () => {
+        const input =
+            'connect failed authorization: Bearer secret-token and Bearer another-token';
+        expect(redactAuthorizationMaterial(input)).toBe(
+            'connect failed authorization: [redacted] and Bearer [redacted]'
+        );
+    });
+
+    it('redacts known secret substrings', () => {
+        expect(redactKnownSecrets('key=super-secret-value', ['super-secret-value'])).toBe(
+            'key=[redacted]'
+        );
+    });
+
+    it('formats log lines without leaking secrets', () => {
+        const message = 'Authorization: Bearer abc123 failed for abc123';
+        expect(formatSafeForLog(message, { knownSecrets: ['abc123'] })).toBe(
+            'authorization: [redacted] failed for [redacted]'
+        );
+    });
+});

--- a/src/temporal/secretRedaction.ts
+++ b/src/temporal/secretRedaction.ts
@@ -1,0 +1,31 @@
+const AUTHORIZATION_BEARER_PATTERN = /authorization\s*:\s*bearer\s+[^\s\r\n]+/gi;
+const BEARER_TOKEN_PATTERN = /\bbearer\s+[^\s\r\n]+/gi;
+const AUTHORIZATION_HEADER_PATTERN = /authorization\s*:\s*[^\s\r\n]+/gi;
+
+export function redactAuthorizationMaterial(text: string): string {
+    return text
+        .replace(AUTHORIZATION_BEARER_PATTERN, 'authorization: [redacted]')
+        .replace(BEARER_TOKEN_PATTERN, 'Bearer [redacted]')
+        .replace(AUTHORIZATION_HEADER_PATTERN, 'authorization: [redacted]');
+}
+
+export function redactKnownSecrets(text: string, secrets: readonly string[]): string {
+    let redacted = redactAuthorizationMaterial(text);
+
+    for (const secret of secrets) {
+        const trimmed = secret.trim();
+        if (trimmed.length === 0) {
+            continue;
+        }
+        redacted = redacted.split(trimmed).join('[redacted]');
+    }
+
+    return redacted;
+}
+
+export function formatSafeForLog(
+    message: string,
+    options: { knownSecrets?: readonly string[] } = {}
+): string {
+    return redactKnownSecrets(message, options.knownSecrets ?? []);
+}

--- a/src/temporal/settingPrecedence.ts
+++ b/src/temporal/settingPrecedence.ts
@@ -60,6 +60,39 @@ export function resolveStringSetting(
     return defaultValue;
 }
 
+export function resolveBooleanSetting(
+    inspected: ConfigurationInspectValue<boolean> | undefined,
+    envVar: string,
+    defaultValue: boolean
+): boolean {
+    if (inspected?.workspaceValue !== undefined) {
+        return inspected.workspaceValue;
+    }
+
+    if (inspected?.globalValue !== undefined) {
+        return inspected.globalValue;
+    }
+
+    const envRaw = process.env[envVar];
+    if (envRaw !== undefined && envRaw.trim() !== '') {
+        const normalized = envRaw.trim().toLowerCase();
+        if (normalized === 'true' || normalized === '1') {
+            return true;
+        }
+        if (normalized === 'false' || normalized === '0') {
+            return false;
+        }
+    }
+
+    return defaultValue;
+}
+
+export function isSettingExplicitlyConfigured<T>(
+    inspected: ConfigurationInspectValue<T> | undefined
+): boolean {
+    return inspected?.workspaceValue !== undefined || inspected?.globalValue !== undefined;
+}
+
 export function resolveOptionalStringSetting(
     inspected: ConfigurationInspectValue<string> | undefined,
     envVar: string

--- a/src/temporal/temporalConfigurationValidation.test.ts
+++ b/src/temporal/temporalConfigurationValidation.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import type { ResolvedExternalSettings } from './externalSettings';
+import {
+    getTemporalConfigurationErrors,
+    isLoopbackHost,
+    parseAddressHost,
+    validateTemporalConfiguration,
+} from './temporalConfigurationValidation';
+
+function externalSettings(overrides: Partial<ResolvedExternalSettings> = {}): ResolvedExternalSettings {
+    return {
+        address: 'localhost:7233',
+        namespace: 'forge-external',
+        taskQueue: 'forge-workflows',
+        authMode: 'apiKey',
+        tlsEnabled: true,
+        tlsServerName: '',
+        ...overrides,
+    };
+}
+
+describe('temporalConfigurationValidation', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.restoreAllMocks();
+    });
+
+    it('parses loopback hosts from address strings', () => {
+        expect(parseAddressHost('localhost:7233')).toBe('localhost');
+        expect(parseAddressHost('127.0.0.1:7233')).toBe('127.0.0.1');
+        expect(parseAddressHost('[::1]:7233')).toBe('::1');
+        expect(isLoopbackHost('localhost')).toBe(true);
+        expect(isLoopbackHost('my-ns.tmprl.cloud')).toBe(false);
+    });
+
+    it('reports missing required external fields', async () => {
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () =>
+                externalSettings({
+                    address: undefined,
+                    namespace: undefined,
+                }),
+            getStoredApiKey: async () => 'test-key',
+        });
+
+        const errors = getTemporalConfigurationErrors(diagnostics);
+        expect(errors).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ path: 'forge.temporal.external.address' }),
+                expect.objectContaining({ path: 'forge.temporal.external.namespace' }),
+            ])
+        );
+    });
+
+    it('blocks apiKey mode without a configured API key', async () => {
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () => externalSettings({ authMode: 'apiKey' }),
+            getStoredApiKey: async () => undefined,
+        });
+
+        expect(getTemporalConfigurationErrors(diagnostics)).toEqual([
+            expect.objectContaining({
+                path: 'forge.temporal.external.apiKey',
+                message: expect.stringContaining('API key not configured'),
+            }),
+        ]);
+    });
+
+    it('accepts apiKey mode when env API key is set', async () => {
+        process.env.FORGE_TEMPORAL_EXTERNAL_API_KEY = 'env-key';
+
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () => externalSettings({ authMode: 'apiKey' }),
+        });
+
+        expect(getTemporalConfigurationErrors(diagnostics)).toEqual([]);
+    });
+
+    it('blocks insecure mode for non-loopback hosts', async () => {
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () =>
+                externalSettings({
+                    authMode: 'insecure',
+                    tlsEnabled: false,
+                    address: 'my-ns.a1b2c.tmprl.cloud:7233',
+                }),
+        });
+
+        expect(getTemporalConfigurationErrors(diagnostics)).toEqual([
+            expect.objectContaining({
+                path: 'forge.temporal.external.address',
+                message: expect.stringContaining('Insecure mode is allowed only for localhost'),
+            }),
+        ]);
+    });
+
+    it('blocks tls disabled unless auth mode is insecure on loopback', async () => {
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () =>
+                externalSettings({
+                    authMode: 'apiKey',
+                    tlsEnabled: false,
+                    address: 'my-ns.a1b2c.tmprl.cloud:7233',
+                }),
+            getStoredApiKey: async () => 'test-key',
+        });
+
+        expect(getTemporalConfigurationErrors(diagnostics)).toEqual([
+            expect.objectContaining({
+                path: 'forge.temporal.external.tls.enabled',
+                message: expect.stringContaining('TLS is required for this auth mode'),
+            }),
+        ]);
+    });
+
+    it('emits info diagnostic when managed-local keys are set in external mode', async () => {
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockImplementation((section?: string) => {
+            if (section === 'forge.temporal.managedLocal') {
+                return {
+                    inspect: (key: string) =>
+                        key === 'grpcPort' ? { workspaceValue: 17233 } : undefined,
+                } as vscode.WorkspaceConfiguration;
+            }
+            if (section === 'forge.temporal.external') {
+                return {
+                    inspect: () => undefined,
+                } as vscode.WorkspaceConfiguration;
+            }
+            return {} as vscode.WorkspaceConfiguration;
+        });
+
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () => externalSettings(),
+            getStoredApiKey: async () => 'test-key',
+        });
+
+        expect(diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    severity: 'warning',
+                    path: 'forge.temporal.managedLocal',
+                }),
+            ])
+        );
+        expect(getTemporalConfigurationErrors(diagnostics)).toEqual([]);
+    });
+
+    it('emits info diagnostic when external keys are set in managedLocal mode', async () => {
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockImplementation((section?: string) => {
+            if (section === 'forge.temporal.external') {
+                return {
+                    inspect: (key: string) =>
+                        key === 'address' ? { workspaceValue: 'unused:7233' } : undefined,
+                } as vscode.WorkspaceConfiguration;
+            }
+            return {} as vscode.WorkspaceConfiguration;
+        });
+
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'managedLocal',
+        });
+
+        expect(diagnostics).toEqual([
+            expect.objectContaining({
+                severity: 'warning',
+                path: 'forge.temporal.external',
+            }),
+        ]);
+    });
+});

--- a/src/temporal/temporalConfigurationValidation.test.ts
+++ b/src/temporal/temporalConfigurationValidation.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
+import {
+    clearRegisteredStoredApiKeyReader,
+    registerStoredApiKeyReader,
+} from './externalCredentials';
 import type { ResolvedExternalSettings } from './externalSettings';
 import {
     getTemporalConfigurationErrors,
@@ -25,6 +29,7 @@ describe('temporalConfigurationValidation', () => {
 
     afterEach(() => {
         process.env = { ...originalEnv };
+        clearRegisteredStoredApiKeyReader();
         vi.restoreAllMocks();
     });
 
@@ -73,6 +78,17 @@ describe('temporalConfigurationValidation', () => {
 
     it('accepts apiKey mode when env API key is set', async () => {
         process.env.FORGE_TEMPORAL_EXTERNAL_API_KEY = 'env-key';
+
+        const diagnostics = await validateTemporalConfiguration({
+            resolveMode: () => 'external',
+            resolveSettings: () => externalSettings({ authMode: 'apiKey' }),
+        });
+
+        expect(getTemporalConfigurationErrors(diagnostics)).toEqual([]);
+    });
+
+    it('uses the registered SecretStorage reader when no override is provided', async () => {
+        registerStoredApiKeyReader(async () => 'stored-key');
 
         const diagnostics = await validateTemporalConfiguration({
             resolveMode: () => 'external',

--- a/src/temporal/temporalConfigurationValidation.ts
+++ b/src/temporal/temporalConfigurationValidation.ts
@@ -1,0 +1,215 @@
+import type { Diagnostic } from '../workflows/types';
+import * as vscode from 'vscode';
+import {
+    EXTERNAL_API_KEY_SECRET_KEY,
+    resolveExternalApiKey,
+    resolveExternalSettings,
+    type ResolvedExternalSettings,
+} from './externalSettings';
+import { isSettingExplicitlyConfigured } from './settingPrecedence';
+import { resolveTemporalMode } from './temporalSettings';
+
+export const TEMPORAL_CONFIGURATION_VALIDATOR_ID = 'forge.temporal.configuration';
+
+const MANAGED_LOCAL_SETTING_KEYS = [
+    'grpcPort',
+    'uiPort',
+    'persistencePath',
+    'namespace',
+    'taskQueue',
+] as const;
+
+const EXTERNAL_SETTING_KEYS = [
+    'address',
+    'namespace',
+    'taskQueue',
+    'auth.mode',
+    'tls.enabled',
+    'tls.serverName',
+] as const;
+
+export interface TemporalConfigurationValidationOptions {
+    resolveMode?: () => ReturnType<typeof resolveTemporalMode>;
+    resolveSettings?: () => ResolvedExternalSettings;
+    getStoredApiKey?: () => Promise<string | undefined>;
+}
+
+function configurationDiagnostic(
+    path: string,
+    message: string,
+    severity: Diagnostic['severity'] = 'error'
+): Diagnostic {
+    return {
+        code: 'forge.temporal.configuration_invalid',
+        severity,
+        path,
+        message,
+        validator_id: TEMPORAL_CONFIGURATION_VALIDATOR_ID,
+    };
+}
+
+export function parseAddressHost(address: string): string | undefined {
+    const trimmed = address.trim();
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    if (trimmed.startsWith('[')) {
+        const closingBracket = trimmed.indexOf(']');
+        if (closingBracket > 1) {
+            return trimmed.slice(1, closingBracket).toLowerCase();
+        }
+        return undefined;
+    }
+
+    const lastColon = trimmed.lastIndexOf(':');
+    if (lastColon <= 0) {
+        return trimmed.toLowerCase();
+    }
+
+    return trimmed.slice(0, lastColon).toLowerCase();
+}
+
+export function isLoopbackHost(host: string | undefined): boolean {
+    if (!host) {
+        return false;
+    }
+
+    const normalized = host.toLowerCase();
+    if (normalized === 'localhost') {
+        return true;
+    }
+    if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
+        return true;
+    }
+    if (normalized.startsWith('127.')) {
+        return true;
+    }
+
+    return false;
+}
+
+function hasPopulatedSettings(
+    section: 'forge.temporal.managedLocal' | 'forge.temporal.external',
+    keys: readonly string[]
+): boolean {
+    const config = vscode.workspace.getConfiguration(section);
+    if (typeof config.inspect !== 'function') {
+        return false;
+    }
+
+    return keys.some((key) => isSettingExplicitlyConfigured(config.inspect(key)));
+}
+
+function hasPopulatedManagedLocalSettings(): boolean {
+    return hasPopulatedSettings('forge.temporal.managedLocal', MANAGED_LOCAL_SETTING_KEYS);
+}
+
+function hasPopulatedExternalSettings(): boolean {
+    return hasPopulatedSettings('forge.temporal.external', EXTERNAL_SETTING_KEYS);
+}
+
+function inactiveFamilyInfoDiagnostics(mode: ReturnType<typeof resolveTemporalMode>): Diagnostic[] {
+    if (mode === 'external' && hasPopulatedManagedLocalSettings()) {
+        return [
+            configurationDiagnostic(
+                'forge.temporal.managedLocal',
+                'Managed-local settings have no effect while forge.temporal.mode is external.',
+                'warning'
+            ),
+        ];
+    }
+
+    if (mode === 'managedLocal' && hasPopulatedExternalSettings()) {
+        return [
+            configurationDiagnostic(
+                'forge.temporal.external',
+                'External settings have no effect while forge.temporal.mode is managedLocal.',
+                'warning'
+            ),
+        ];
+    }
+
+    return [];
+}
+
+function validateExternalSettings(
+    settings: ResolvedExternalSettings,
+    apiKey: string | undefined
+): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+
+    if (!settings.address) {
+        diagnostics.push(
+            configurationDiagnostic(
+                'forge.temporal.external.address',
+                'External Temporal address is required when forge.temporal.mode is external.'
+            )
+        );
+    }
+
+    if (!settings.namespace) {
+        diagnostics.push(
+            configurationDiagnostic(
+                'forge.temporal.external.namespace',
+                'External Temporal namespace is required when forge.temporal.mode is external.'
+            )
+        );
+    }
+
+    if (settings.authMode === 'apiKey' && !apiKey) {
+        diagnostics.push(
+            configurationDiagnostic(
+                EXTERNAL_API_KEY_SECRET_KEY,
+                'API key not configured. Run Forge: Set Temporal API Key or set FORGE_TEMPORAL_EXTERNAL_API_KEY.'
+            )
+        );
+    }
+
+    if (settings.authMode === 'insecure') {
+        const host = settings.address ? parseAddressHost(settings.address) : undefined;
+        if (!isLoopbackHost(host)) {
+            diagnostics.push(
+                configurationDiagnostic(
+                    'forge.temporal.external.address',
+                    'Insecure mode is allowed only for localhost loopback hosts.'
+                )
+            );
+        }
+    }
+
+    if (!settings.tlsEnabled && settings.authMode !== 'insecure') {
+        diagnostics.push(
+            configurationDiagnostic(
+                'forge.temporal.external.tls.enabled',
+                'TLS is required for this auth mode. Set forge.temporal.external.tls.enabled to true or use auth.mode insecure on loopback only.'
+            )
+        );
+    }
+
+    return diagnostics;
+}
+
+export async function validateTemporalConfiguration(
+    options: TemporalConfigurationValidationOptions = {}
+): Promise<Diagnostic[]> {
+    const resolveMode = options.resolveMode ?? resolveTemporalMode;
+    const mode = resolveMode();
+    const infoDiagnostics = inactiveFamilyInfoDiagnostics(mode);
+
+    if (mode !== 'external') {
+        return infoDiagnostics;
+    }
+
+    const settings = options.resolveSettings?.() ?? resolveExternalSettings();
+    const apiKey = await resolveExternalApiKey(options.getStoredApiKey);
+    const errorDiagnostics = validateExternalSettings(settings, apiKey);
+
+    return [...infoDiagnostics, ...errorDiagnostics];
+}
+
+export function getTemporalConfigurationErrors(
+    diagnostics: Diagnostic[]
+): Diagnostic[] {
+    return diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+}

--- a/src/temporal/temporalConfigurationValidation.ts
+++ b/src/temporal/temporalConfigurationValidation.ts
@@ -1,5 +1,6 @@
 import type { Diagnostic } from '../workflows/types';
 import * as vscode from 'vscode';
+import { getRegisteredStoredApiKeyReader } from './externalCredentials';
 import {
     EXTERNAL_API_KEY_SECRET_KEY,
     resolveExternalApiKey,
@@ -202,7 +203,8 @@ export async function validateTemporalConfiguration(
     }
 
     const settings = options.resolveSettings?.() ?? resolveExternalSettings();
-    const apiKey = await resolveExternalApiKey(options.getStoredApiKey);
+    const getStoredApiKey = options.getStoredApiKey ?? getRegisteredStoredApiKeyReader();
+    const apiKey = await resolveExternalApiKey(getStoredApiKey);
     const errorDiagnostics = validateExternalSettings(settings, apiKey);
 
     return [...infoDiagnostics, ...errorDiagnostics];

--- a/src/temporal/temporalHealthSurfaces.ts
+++ b/src/temporal/temporalHealthSurfaces.ts
@@ -1,6 +1,13 @@
 import * as vscode from 'vscode';
+import { ExternalTemporalSupervisor } from './ExternalTemporalSupervisor';
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
 import {
+    formatExternalConnectFailedNotification,
+    formatExternalReadyNotification,
+    formatExternalStateTransitionLogLine,
+    formatExternalStatusBarLabel,
+    formatExternalStatusBarTooltip,
+    formatInsecureModeWarning,
     formatManagedLocalStatusBarLabel,
     formatManagedLocalStatusBarTooltip,
     formatReadyNotification,
@@ -8,7 +15,13 @@ import {
     formatStateTransitionLogLine,
     formatWorkflowBlockedNotification,
 } from './temporalPresentation';
-import type { ManagedLocalHealthState, ManagedLocalSupervisorConfig } from './types';
+import type { ResolvedExternalSettings } from './externalSettings';
+import type {
+    ExternalTemporalHealthState,
+    ExternalTemporalSupervisorConfig,
+    ManagedLocalHealthState,
+    ManagedLocalSupervisorConfig,
+} from './types';
 
 export const TEMPORAL_OUTPUT_CHANNEL_NAME = 'Forge Temporal';
 
@@ -116,4 +129,72 @@ function notifyForState(
             )
         );
     }
+}
+
+export function registerExternalTemporalHealthSurfaces(
+    context: vscode.ExtensionContext,
+    supervisor: ExternalTemporalSupervisor,
+    config: ExternalTemporalSupervisorConfig,
+    resolveSettings: () => ResolvedExternalSettings,
+    outputChannel: vscode.OutputChannel
+): void {
+    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    context.subscriptions.push(statusBarItem);
+
+    const applyState = (state: ExternalTemporalHealthState) => {
+        const settings = resolveSettings();
+        const address = settings.address ?? 'unknown';
+        const namespace = settings.namespace ?? 'unknown';
+
+        statusBarItem.text = formatExternalStatusBarLabel(state);
+        statusBarItem.tooltip = formatExternalStatusBarTooltip({
+            address,
+            namespace,
+            authMode: settings.authMode,
+            tlsEnabled: settings.tlsEnabled,
+        });
+        statusBarItem.show();
+
+        const connectError = supervisor.getConnectError();
+        outputChannel.appendLine(
+            formatExternalStateTransitionLogLine(state, {
+                windowId: config.windowId,
+                address,
+                namespace,
+                authMode: settings.authMode,
+                tlsEnabled: settings.tlsEnabled,
+                probeErrorCode: connectError?.probeErrorCode,
+            })
+        );
+
+        if (state === 'ready') {
+            void vscode.window.showInformationMessage(
+                formatExternalReadyNotification(namespace, address)
+            );
+            return;
+        }
+
+        if (state === 'connect_failed') {
+            if (!connectError) {
+                return;
+            }
+            void vscode.window.showErrorMessage(
+                formatExternalConnectFailedNotification(connectError.remediation, address)
+            );
+            return;
+        }
+
+        if (state === 'connecting' && settings.authMode === 'insecure') {
+            outputChannel.appendLine(
+                `[forge.temporal.external] warning ${formatInsecureModeWarning(address)}`
+            );
+        }
+    };
+
+    applyState(supervisor.getHealthState());
+
+    const unsubscribe = supervisor.onStateChange((state) => {
+        applyState(state);
+    });
+    context.subscriptions.push({ dispose: unsubscribe });
 }

--- a/src/temporal/temporalPresentation.test.ts
+++ b/src/temporal/temporalPresentation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+    formatExternalConnectFailedNotification,
+    formatExternalReadyNotification,
+    formatExternalStatusBarLabel,
     formatManagedLocalStatusBarLabel,
     formatPersistencePathForDisplay,
     formatReadyNotification,
@@ -66,6 +69,37 @@ describe('temporalPresentation', () => {
     it('uses workflow blocked notification copy from contract', () => {
         expect(formatWorkflowBlockedNotification()).toBe(
             'Workflow runs are blocked until Temporal is ready. See Forge Temporal output for details.'
+        );
+    });
+
+    describe('formatExternalStatusBarLabel', () => {
+        it('maps external health states to contract labels', () => {
+            expect(formatExternalStatusBarLabel('connecting')).toBe(
+                '$(pulse) Temporal: connecting…'
+            );
+            expect(formatExternalStatusBarLabel('connect_failed')).toBe(
+                '$(pulse) Temporal: failed'
+            );
+        });
+    });
+
+    describe('formatExternalConnectFailedNotification', () => {
+        it('uses auth remediation copy', () => {
+            expect(formatExternalConnectFailedNotification('auth', 'host:7233')).toBe(
+                'Forge could not connect to Temporal — authentication failed. Run **Forge: Set Temporal API Key** or check `forge.temporal.external.auth.mode`.'
+            );
+        });
+
+        it('uses address remediation copy', () => {
+            expect(formatExternalConnectFailedNotification('address', 'host:7233')).toBe(
+                'Forge could not connect to Temporal — host:7233 is unreachable. Check `forge.temporal.external.address` and network access.'
+            );
+        });
+    });
+
+    it('uses external ready notification copy from contract', () => {
+        expect(formatExternalReadyNotification('forge-ns', 'host:7233')).toBe(
+            'Forge Temporal ready — connected to forge-ns at host:7233.'
         );
     });
 });

--- a/src/temporal/temporalPresentation.ts
+++ b/src/temporal/temporalPresentation.ts
@@ -1,5 +1,10 @@
 import path from 'path';
-import type { ManagedLocalHealthState, StartFailureRemediation } from './types';
+import type {
+    ExternalConnectFailureRemediation,
+    ExternalTemporalHealthState,
+    ManagedLocalHealthState,
+    StartFailureRemediation,
+} from './types';
 
 export interface ManagedLocalPresentationContext {
     windowId: string;
@@ -78,4 +83,77 @@ export function formatStateTransitionLogLine(
     const exitCodePart =
         context.exitCode !== undefined ? ` exitCode=${context.exitCode}` : '';
     return `[forge.temporal.local] state=${state} windowId=${context.windowId} grpcPort=${context.grpcPort} persistencePath=${context.persistencePathDisplay}${exitCodePart}`;
+}
+
+export interface ExternalPresentationContext {
+    windowId: string;
+    address: string;
+    namespace: string;
+    authMode: string;
+    tlsEnabled: boolean;
+    probeErrorCode?: string;
+}
+
+export function formatExternalStatusBarLabel(state: ExternalTemporalHealthState): string {
+    switch (state) {
+        case 'idle':
+            return '$(pulse) Temporal: idle';
+        case 'connecting':
+            return '$(pulse) Temporal: connecting…';
+        case 'ready':
+            return '$(pulse) Temporal: ready';
+        case 'unhealthy':
+            return '$(pulse) Temporal: unhealthy';
+        case 'connect_failed':
+            return '$(pulse) Temporal: failed';
+        case 'disconnected':
+            return '$(pulse) Temporal: disconnected';
+    }
+}
+
+export function formatExternalStatusBarTooltip(context: {
+    address: string;
+    namespace: string;
+    authMode: string;
+    tlsEnabled: boolean;
+}): string {
+    return [
+        `address: ${context.address}`,
+        `namespace: ${context.namespace}`,
+        `authMode: ${context.authMode}`,
+        `tlsEnabled: ${context.tlsEnabled}`,
+    ].join('\n');
+}
+
+export function formatExternalReadyNotification(namespace: string, address: string): string {
+    return `Forge Temporal ready — connected to ${namespace} at ${address}.`;
+}
+
+export function formatExternalConnectFailedNotification(
+    remediation: ExternalConnectFailureRemediation,
+    address: string
+): string {
+    switch (remediation) {
+        case 'auth':
+            return 'Forge could not connect to Temporal — authentication failed. Run **Forge: Set Temporal API Key** or check `forge.temporal.external.auth.mode`.';
+        case 'tls':
+            return `Forge could not connect to Temporal — TLS handshake failed at ${address}. Verify \`forge.temporal.external.tls.enabled\` and cluster certificates.`;
+        case 'address':
+            return `Forge could not connect to Temporal — ${address} is unreachable. Check \`forge.temporal.external.address\` and network access.`;
+        case 'config':
+            return 'Forge Temporal configuration is incomplete — external settings are required for external mode. See Forge Temporal output.';
+    }
+}
+
+export function formatInsecureModeWarning(address: string): string {
+    return `Forge Temporal is using insecure (plaintext) gRPC to ${address}. Use only for local development.`;
+}
+
+export function formatExternalStateTransitionLogLine(
+    state: ExternalTemporalHealthState,
+    context: ExternalPresentationContext
+): string {
+    const probeErrorPart =
+        context.probeErrorCode !== undefined ? ` probeErrorCode=${context.probeErrorCode}` : '';
+    return `[forge.temporal.external] state=${state} windowId=${context.windowId} address=${context.address} namespace=${context.namespace} authMode=${context.authMode} tlsEnabled=${context.tlsEnabled}${probeErrorPart}`;
 }

--- a/src/temporal/temporalReadinessGate.test.ts
+++ b/src/temporal/temporalReadinessGate.test.ts
@@ -8,11 +8,35 @@ import {
 } from './temporalReadinessGate';
 
 describe('temporalReadinessGate', () => {
-    it('skips readiness when mode is external', async () => {
+    it('validates external configuration before skipping managed-local readiness', async () => {
         await expect(
             gateTemporalReadiness({
                 resolveMode: () => 'external',
                 getSupervisor: () => undefined,
+                resolveSettings: () => ({
+                    address: undefined,
+                    namespace: 'forge-external',
+                    taskQueue: 'forge-workflows',
+                    authMode: 'apiKey',
+                    tlsEnabled: true,
+                    tlsServerName: '',
+                }),
+                getStoredApiKey: async () => 'test-key',
+            })
+        ).rejects.toBeInstanceOf(TemporalConfigurationInvalidError);
+
+        await expect(
+            gateTemporalReadiness({
+                resolveMode: () => 'external',
+                getSupervisor: () => undefined,
+                resolveSettings: () => ({
+                    address: 'localhost:7233',
+                    namespace: 'forge-external',
+                    taskQueue: 'forge-workflows',
+                    authMode: 'insecure',
+                    tlsEnabled: false,
+                    tlsServerName: '',
+                }),
             })
         ).resolves.toBeUndefined();
     });

--- a/src/temporal/temporalReadinessGate.test.ts
+++ b/src/temporal/temporalReadinessGate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { ExternalReadinessBlockedError, ExternalTemporalSupervisor } from './ExternalTemporalSupervisor';
 import { TemporalReadinessBlockedError } from './TemporalLocalSupervisor';
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
 import {
@@ -8,11 +9,11 @@ import {
 } from './temporalReadinessGate';
 
 describe('temporalReadinessGate', () => {
-    it('validates external configuration before skipping managed-local readiness', async () => {
+    it('validates external configuration before running external preflight', async () => {
         await expect(
             gateTemporalReadiness({
                 resolveMode: () => 'external',
-                getSupervisor: () => undefined,
+                getExternalSupervisor: () => undefined,
                 resolveSettings: () => ({
                     address: undefined,
                     namespace: 'forge-external',
@@ -24,11 +25,17 @@ describe('temporalReadinessGate', () => {
                 getStoredApiKey: async () => 'test-key',
             })
         ).rejects.toBeInstanceOf(TemporalConfigurationInvalidError);
+    });
+
+    it('runs external preflight when configuration is valid', async () => {
+        const supervisor = {
+            ensureReady: vi.fn(async () => undefined),
+        } as unknown as ExternalTemporalSupervisor;
 
         await expect(
             gateTemporalReadiness({
                 resolveMode: () => 'external',
-                getSupervisor: () => undefined,
+                getExternalSupervisor: () => supervisor,
                 resolveSettings: () => ({
                     address: 'localhost:7233',
                     namespace: 'forge-external',
@@ -39,6 +46,42 @@ describe('temporalReadinessGate', () => {
                 }),
             })
         ).resolves.toBeUndefined();
+
+        expect(supervisor.ensureReady).toHaveBeenCalledOnce();
+    });
+
+    it('blocks workflow run start when external preflight fails', async () => {
+        const supervisor = {
+            ensureReady: vi.fn(async () => {
+                throw new ExternalReadinessBlockedError(
+                    {
+                        remediation: 'auth',
+                        message: 'External Temporal authentication failed.',
+                    },
+                    'connect_failed'
+                );
+            }),
+        } as unknown as ExternalTemporalSupervisor;
+
+        await expect(
+            gateTemporalReadiness({
+                resolveMode: () => 'external',
+                getExternalSupervisor: () => supervisor,
+                resolveSettings: () => ({
+                    address: 'localhost:7233',
+                    namespace: 'forge-external',
+                    taskQueue: 'forge-workflows',
+                    authMode: 'apiKey',
+                    tlsEnabled: true,
+                    tlsServerName: '',
+                }),
+                getStoredApiKey: async () => 'test-key',
+            })
+        ).rejects.toBeInstanceOf(TemporalConfigurationInvalidError);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+            'Workflow runs are blocked until Temporal is ready. See Forge Temporal output for details.'
+        );
     });
 
     it('blocks workflow run start when supervisor is start_failed', async () => {

--- a/src/temporal/temporalReadinessGate.ts
+++ b/src/temporal/temporalReadinessGate.ts
@@ -1,6 +1,11 @@
 import type { Diagnostic } from '../workflows/types';
 import { TemporalLocalSupervisor, TemporalReadinessBlockedError } from './TemporalLocalSupervisor';
 import { notifyWorkflowBlockedByTemporal } from './temporalHealthSurfaces';
+import {
+    getTemporalConfigurationErrors,
+    validateTemporalConfiguration,
+    type TemporalConfigurationValidationOptions,
+} from './temporalConfigurationValidation';
 import { resolveTemporalMode } from './temporalSettings';
 
 export const TEMPORAL_READINESS_VALIDATOR_ID = 'forge.temporal.readiness';
@@ -15,7 +20,7 @@ export class TemporalConfigurationInvalidError extends Error {
     }
 }
 
-export interface TemporalReadinessGateOptions {
+export interface TemporalReadinessGateOptions extends TemporalConfigurationValidationOptions {
     getSupervisor?: () => TemporalLocalSupervisor | undefined;
     resolveMode?: () => ReturnType<typeof resolveTemporalMode>;
 }
@@ -52,9 +57,16 @@ export async function gateTemporalReadiness(
     const resolveMode = options.resolveMode ?? resolveTemporalMode;
     const mode = resolveMode();
 
-    if (mode !== 'managedLocal') {
+    if (mode === 'external') {
+        const diagnostics = await validateTemporalConfiguration(options);
+        const errors = getTemporalConfigurationErrors(diagnostics);
+        if (errors.length > 0) {
+            throw new TemporalConfigurationInvalidError(errors);
+        }
         return;
     }
+
+    await validateTemporalConfiguration(options);
 
     const supervisor = options.getSupervisor?.();
     if (!supervisor) {

--- a/src/temporal/temporalReadinessGate.ts
+++ b/src/temporal/temporalReadinessGate.ts
@@ -1,6 +1,11 @@
 import type { Diagnostic } from '../workflows/types';
+import { ExternalReadinessBlockedError, ExternalTemporalSupervisor } from './ExternalTemporalSupervisor';
 import { TemporalLocalSupervisor, TemporalReadinessBlockedError } from './TemporalLocalSupervisor';
 import { notifyWorkflowBlockedByTemporal } from './temporalHealthSurfaces';
+import {
+    getExternalTemporalSupervisor,
+    getTemporalLocalSupervisor,
+} from './temporalWindowRegistry';
 import {
     getTemporalConfigurationErrors,
     validateTemporalConfiguration,
@@ -22,6 +27,7 @@ export class TemporalConfigurationInvalidError extends Error {
 
 export interface TemporalReadinessGateOptions extends TemporalConfigurationValidationOptions {
     getSupervisor?: () => TemporalLocalSupervisor | undefined;
+    getExternalSupervisor?: () => ExternalTemporalSupervisor | undefined;
     resolveMode?: () => ReturnType<typeof resolveTemporalMode>;
 }
 
@@ -38,6 +44,31 @@ function remediationMessage(remediation: string): string {
     }
 }
 
+function externalConnectRemediationMessage(remediation: string): string {
+    switch (remediation) {
+        case 'auth':
+            return 'Run Forge: Set Temporal API Key or check forge.temporal.external.auth.mode.';
+        case 'tls':
+            return 'Verify forge.temporal.external.tls.enabled and cluster certificates.';
+        case 'address':
+            return 'Check forge.temporal.external.address and network access.';
+        default:
+            return 'Fix external Temporal settings. See Forge Temporal output for details.';
+    }
+}
+
+function externalConnectInvalidDiagnostic(
+    message: string,
+    remediation: string
+): Diagnostic {
+    return {
+        code: 'forge.temporal.configuration_invalid',
+        severity: 'error',
+        path: 'forge.temporal.external',
+        message: `${message} ${externalConnectRemediationMessage(remediation)}`,
+        validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
+    };
+}
 function configurationInvalidDiagnostic(
     message: string,
     remediation: string
@@ -63,12 +94,39 @@ export async function gateTemporalReadiness(
         if (errors.length > 0) {
             throw new TemporalConfigurationInvalidError(errors);
         }
+
+        const supervisor =
+            options.getExternalSupervisor?.() ?? getExternalTemporalSupervisor();
+        if (!supervisor) {
+            throw new TemporalConfigurationInvalidError([
+                {
+                    code: 'forge.temporal.configuration_invalid',
+                    severity: 'error',
+                    path: 'forge.temporal.external',
+                    message:
+                        'External Temporal supervisor is not registered for this window. Reload the window and retry.',
+                    validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
+                },
+            ]);
+        }
+
+        try {
+            await supervisor.ensureReady();
+        } catch (error) {
+            if (error instanceof ExternalReadinessBlockedError) {
+                notifyWorkflowBlockedByTemporal();
+                throw new TemporalConfigurationInvalidError([
+                    externalConnectInvalidDiagnostic(error.message, error.remediation),
+                ]);
+            }
+            throw error;
+        }
         return;
     }
 
     await validateTemporalConfiguration(options);
 
-    const supervisor = options.getSupervisor?.();
+    const supervisor = options.getSupervisor?.() ?? getTemporalLocalSupervisor();
     if (!supervisor) {
         throw new TemporalConfigurationInvalidError([
             {

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -1,26 +1,73 @@
 import * as vscode from 'vscode';
+import {
+    ExternalTemporalSupervisor,
+} from './ExternalTemporalSupervisor';
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
+import { getRegisteredStoredApiKeyReader } from './externalCredentials';
+import { resolveExternalApiKey, resolveExternalSettings } from './externalSettings';
 import {
     ensurePersistenceDirectory,
     resolveManagedLocalSettings,
 } from './managedLocalSettings';
+import { resolveTemporalMode } from './temporalSettings';
 import {
     createTemporalOutputChannel,
+    registerExternalTemporalHealthSurfaces,
     registerManagedLocalTemporalHealthSurfaces,
 } from './temporalHealthSurfaces';
 import { formatPersistencePathForDisplay } from './temporalPresentation';
-import type { ManagedLocalSupervisorConfig } from './types';
+import type { ExternalTemporalSupervisorConfig, ManagedLocalSupervisorConfig } from './types';
 
-let supervisor: TemporalLocalSupervisor | undefined;
+let localSupervisor: TemporalLocalSupervisor | undefined;
+let externalSupervisor: ExternalTemporalSupervisor | undefined;
 
 export function getTemporalLocalSupervisor(): TemporalLocalSupervisor | undefined {
-    return supervisor;
+    return localSupervisor;
+}
+
+export function getExternalTemporalSupervisor(): ExternalTemporalSupervisor | undefined {
+    return externalSupervisor;
 }
 
 export function registerTemporalLocalSupervisor(
     context: vscode.ExtensionContext
-): TemporalLocalSupervisor {
+): TemporalLocalSupervisor | ExternalTemporalSupervisor {
     const windowId = vscode.env.sessionId;
+    const outputChannel = createTemporalOutputChannel(context);
+    const mode = resolveTemporalMode();
+
+    if (mode === 'external') {
+        const externalConfig: ExternalTemporalSupervisorConfig = {
+            windowId,
+            resolveSettings: resolveExternalSettings,
+            resolveApiKey: () =>
+                resolveExternalApiKey(getRegisteredStoredApiKeyReader()),
+        };
+
+        externalSupervisor = new ExternalTemporalSupervisor(externalConfig, {
+            log: (line) => {
+                outputChannel.appendLine(line);
+            },
+        });
+
+        registerExternalTemporalHealthSurfaces(
+            context,
+            externalSupervisor,
+            externalConfig,
+            resolveExternalSettings,
+            outputChannel
+        );
+
+        context.subscriptions.push({
+            dispose: () => {
+                void externalSupervisor?.stop();
+                externalSupervisor = undefined;
+            },
+        });
+
+        return externalSupervisor;
+    }
+
     const settings = resolveManagedLocalSettings({
         globalStoragePath: context.globalStorageUri.fsPath,
         windowId,
@@ -44,9 +91,7 @@ export function registerTemporalLocalSupervisor(
         taskQueue: settings.taskQueue,
     };
 
-    const outputChannel = createTemporalOutputChannel(context);
-
-    supervisor = new TemporalLocalSupervisor(config, {
+    localSupervisor = new TemporalLocalSupervisor(config, {
         log: (line) => {
             outputChannel.appendLine(line);
         },
@@ -54,7 +99,7 @@ export function registerTemporalLocalSupervisor(
 
     registerManagedLocalTemporalHealthSurfaces(
         context,
-        supervisor,
+        localSupervisor,
         config,
         persistencePathDisplay,
         outputChannel
@@ -62,15 +107,17 @@ export function registerTemporalLocalSupervisor(
 
     context.subscriptions.push({
         dispose: () => {
-            void supervisor?.stop();
-            supervisor = undefined;
+            void localSupervisor?.stop();
+            localSupervisor = undefined;
         },
     });
 
-    return supervisor;
+    return localSupervisor;
 }
 
 export async function shutdownTemporalLocalSupervisor(): Promise<void> {
-    await supervisor?.stop();
-    supervisor = undefined;
+    await localSupervisor?.stop();
+    localSupervisor = undefined;
+    await externalSupervisor?.stop();
+    externalSupervisor = undefined;
 }

--- a/src/temporal/types.ts
+++ b/src/temporal/types.ts
@@ -6,6 +6,28 @@ export type ManagedLocalHealthState =
     | 'start_failed'
     | 'stopped';
 
+export type ExternalTemporalHealthState =
+    | 'idle'
+    | 'connecting'
+    | 'ready'
+    | 'unhealthy'
+    | 'connect_failed'
+    | 'disconnected';
+
+export type ExternalConnectFailureRemediation = 'auth' | 'tls' | 'address' | 'config';
+
+export interface ExternalConnectError {
+    remediation: ExternalConnectFailureRemediation;
+    message: string;
+    probeErrorCode?: string;
+}
+
+export interface ExternalTemporalSupervisorConfig {
+    windowId: string;
+    resolveSettings: () => import('./externalSettings').ResolvedExternalSettings;
+    resolveApiKey: () => Promise<string | undefined>;
+}
+
 export type StartFailureRemediation = 'port' | 'asset' | 'permission';
 
 export interface ManagedLocalSupervisorConfig {
@@ -48,4 +70,14 @@ export type ChildProcessSpawner = (
 export type HealthProber = (options: {
     address: string;
     namespace: string;
+}) => Promise<boolean>;
+
+export type ExternalPreflightProber = (options: {
+    settings: import('./externalSettings').ResolvedExternalSettings;
+    apiKey: string | undefined;
+}) => Promise<void>;
+
+export type ExternalHealthProber = (options: {
+    settings: import('./externalSettings').ResolvedExternalSettings;
+    apiKey: string | undefined;
 }) => Promise<boolean>;

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -19,6 +19,7 @@ export const workspace = {
     getWorkspaceFolder: vi.fn(),
     getConfiguration: vi.fn(() => ({
         get: vi.fn(),
+        inspect: vi.fn(() => undefined),
     })),
     workspaceFolders: []
 };


### PR DESCRIPTION
## Description

Adds external Temporal support on the shared `feature/issue-19` branch:

- **#37** — `forge.temporal.external.*` VS Code settings, environment variable precedence, and mode-aware configuration validation
- **#38** — VS Code SecretStorage binding for external API keys, set/clear commands, connection option builder, and log redaction helpers
- **#39** — Lazy external connection preflight gate, health state machine, and Output/status bar/notification surfaces

## Motivation and Context

Parent issue #19 tracks external and Cloud Temporal support. Managed-local mode landed in #18. This PR delivers external configuration, credential binding, and connection preflight so workflow runs can authenticate and block safely until Temporal is ready.

Closes #37
Closes #38
Closes #39

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] All new and existing tests pass (`npm test`)
- [x] Linter passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

## Additional Notes

- External mode registers `ExternalTemporalSupervisor` instead of the managed-local supervisor.
- `gateTemporalReadiness` validates configuration then runs external preflight before allowing run start.
- No auto-fallback to managed-local on external connect failure.