### PR TITLE
feat(temporal): out-of-host worker supervisor (#20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,6 @@ jobs:
         run: npm test
         continue-on-error: false
 
+      - name: Verify packaged launch assets
+        run: bash scripts/verify-packaging.sh
+

--- a/resources/workflow/worker/start-worker.js
+++ b/resources/workflow/worker/start-worker.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { NativeConnection, Worker } = require('@temporalio/worker');
+
+function resolveSetting(envKey, fallback) {
+    const value = process.env[envKey];
+    if (value !== undefined && value.length > 0) {
+        return value;
+    }
+    return fallback;
+}
+
+function resolveBooleanSetting(envKey, fallback) {
+    const value = process.env[envKey];
+    if (value === undefined || value.length === 0) {
+        return fallback;
+    }
+    return value === 'true' || value === '1';
+}
+
+function buildConnectionOptions() {
+    const mode = resolveSetting('FORGE_TEMPORAL_MODE', 'managedLocal');
+    const address =
+        mode === 'external'
+            ? resolveSetting('FORGE_TEMPORAL_EXTERNAL_ADDRESS', '')
+            : resolveSetting(
+                  'FORGE_TEMPORAL_ADDRESS',
+                  `127.0.0.1:${resolveSetting('FORGE_TEMPORAL_MANAGED_LOCAL_GRPC_PORT', '7233')}`
+              );
+
+    if (!address) {
+        throw new Error('Temporal worker address is not configured.');
+    }
+
+    const authMode = resolveSetting('FORGE_TEMPORAL_EXTERNAL_AUTH_MODE', 'apiKey');
+    const tlsEnabled = resolveBooleanSetting('FORGE_TEMPORAL_EXTERNAL_TLS_ENABLED', true);
+    const options = { address };
+
+    if (mode === 'external') {
+        if (authMode === 'insecure' || !tlsEnabled) {
+            options.tls = false;
+        } else {
+            const serverName = resolveSetting('FORGE_TEMPORAL_EXTERNAL_TLS_SERVER_NAME', '');
+            options.tls = serverName ? { serverNameOverride: serverName } : true;
+        }
+
+        if (authMode === 'apiKey') {
+            const apiKey = resolveSetting('FORGE_TEMPORAL_EXTERNAL_API_KEY', '');
+            if (apiKey) {
+                options.apiKey = apiKey;
+            }
+        }
+    }
+
+    return options;
+}
+
+function resolveNamespace() {
+    const mode = resolveSetting('FORGE_TEMPORAL_MODE', 'managedLocal');
+    if (mode === 'external') {
+        return resolveSetting('FORGE_TEMPORAL_EXTERNAL_NAMESPACE', '');
+    }
+    return resolveSetting('FORGE_TEMPORAL_MANAGED_LOCAL_NAMESPACE', 'forge-local');
+}
+
+function resolveTaskQueue() {
+    const mode = resolveSetting('FORGE_TEMPORAL_MODE', 'managedLocal');
+    if (mode === 'external') {
+        return resolveSetting('FORGE_TEMPORAL_EXTERNAL_TASK_QUEUE', 'forge-workflows');
+    }
+    return resolveSetting('FORGE_TEMPORAL_MANAGED_LOCAL_TASK_QUEUE', 'forge-workflows');
+}
+
+async function main() {
+    const namespace = resolveNamespace();
+    const taskQueue = resolveTaskQueue();
+
+    if (!namespace) {
+        throw new Error('Temporal worker namespace is not configured.');
+    }
+
+    const connection = await NativeConnection.connect(buildConnectionOptions());
+    const worker = await Worker.create({
+        connection,
+        namespace,
+        taskQueue,
+        activities: {},
+    });
+
+    process.stdout.write(`FORGE_WORKER_READY:taskQueue=${taskQueue}\n`);
+
+    process.on('SIGTERM', () => {
+        worker.shutdown();
+    });
+    process.on('SIGINT', () => {
+        worker.shutdown();
+    });
+
+    await worker.run();
+    await connection.close().catch(() => undefined);
+}
+
+main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+});

--- a/scripts/verify-packaging.sh
+++ b/scripts/verify-packaging.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DEV_SERVER_ENTRY="resources/workflow/temporal/start-dev-server.js"
+WORKER_ENTRY="resources/workflow/worker/start-worker.js"
+
+if [[ ! -f "$DEV_SERVER_ENTRY" ]]; then
+    echo "verify-packaging: missing dev server entry at $DEV_SERVER_ENTRY" >&2
+    exit 1
+fi
+
+if [[ ! -f "$WORKER_ENTRY" ]]; then
+    echo "verify-packaging: missing worker entry at $WORKER_ENTRY" >&2
+    exit 1
+fi
+
+node -e "
+const path = require('path');
+const devServer = path.join(process.cwd(), '$DEV_SERVER_ENTRY');
+const worker = path.join(process.cwd(), '$WORKER_ENTRY');
+require('@temporalio/worker');
+require.resolve('@temporalio/worker/package.json');
+require.resolve('@temporalio/core-bridge');
+console.log('dependency closure ok for', devServer, 'and', worker);
+"
+
+npm run package >/dev/null
+
+shopt -s nullglob
+VSIX=(*.vsix)
+shopt -u nullglob
+
+if [[ ${#VSIX[@]} -eq 0 ]]; then
+    echo "verify-packaging: no packaged VSIX produced" >&2
+    exit 1
+fi
+
+VSIX_PATH="${VSIX[0]}"
+if [[ ${#VSIX[@]} -gt 1 ]]; then
+    VSIX_PATH="$(ls -t "${VSIX[@]}" | head -1)"
+fi
+
+VSIX_LISTING="$(zipinfo -1 "$VSIX_PATH")"
+
+grep -Fxq "extension/$DEV_SERVER_ENTRY" <<< "$VSIX_LISTING" || {
+    echo "verify-packaging: dev server entry missing from VSIX" >&2
+    exit 1
+}
+
+grep -Fxq "extension/$WORKER_ENTRY" <<< "$VSIX_LISTING" || {
+    echo "verify-packaging: worker entry missing from VSIX" >&2
+    exit 1
+}
+
+echo "verify-packaging: launch assets present in VSIX ($VSIX_PATH)"

--- a/src/temporal/ExternalTemporalSupervisor.test.ts
+++ b/src/temporal/ExternalTemporalSupervisor.test.ts
@@ -17,9 +17,11 @@ const externalSettings: ResolvedExternalSettings = {
 function createSupervisor(options: {
     preflightResults: Array<void | Error>;
     probeResults?: boolean[];
+    workerPollResults?: boolean[];
 }) {
     let preflightIndex = 0;
     let probeIndex = 0;
+    let workerPollIndex = 0;
 
     const supervisor = new ExternalTemporalSupervisor(
         {
@@ -40,6 +42,11 @@ function createSupervisor(options: {
                 probeIndex += 1;
                 return result;
             },
+            probeWorkerPoll: async () => {
+                const result = options.workerPollResults?.[workerPollIndex] ?? true;
+                workerPollIndex += 1;
+                return result;
+            },
         }
     );
 
@@ -48,11 +55,40 @@ function createSupervisor(options: {
 
 describe('ExternalTemporalSupervisor', () => {
     it('starts idle and transitions to ready after preflight succeeds', async () => {
-        const supervisor = createSupervisor({ preflightResults: [undefined] });
+        const supervisor = createSupervisor({
+            preflightResults: [undefined],
+            workerPollResults: [true],
+        });
 
         expect(supervisor.getHealthState()).toBe('idle');
         await supervisor.ensureReady();
         expect(supervisor.getHealthState()).toBe('ready');
+    });
+
+    it('transitions to unhealthy when server is reachable but no worker polls', async () => {
+        const supervisor = createSupervisor({
+            preflightResults: [undefined],
+            workerPollResults: [false],
+        });
+
+        await supervisor.ensureReady();
+        expect(supervisor.getHealthState()).toBe('unhealthy');
+    });
+
+    it('transitions from unhealthy to ready when worker polling starts', async () => {
+        vi.useFakeTimers();
+        const supervisor = createSupervisor({
+            preflightResults: [undefined],
+            workerPollResults: [false, true],
+            probeResults: [true],
+        });
+
+        await supervisor.ensureReady();
+        expect(supervisor.getHealthState()).toBe('unhealthy');
+
+        await vi.advanceTimersByTimeAsync(600);
+        expect(supervisor.getHealthState()).toBe('ready');
+        vi.useRealTimers();
     });
 
     it('transitions to connect_failed on auth failure and blocks subsequent runs', async () => {
@@ -80,6 +116,7 @@ describe('ExternalTemporalSupervisor', () => {
         vi.useFakeTimers();
         const supervisor = createSupervisor({
             preflightResults: [undefined],
+            workerPollResults: [true, false, false, false],
             probeResults: [false, false, false],
         });
 

--- a/src/temporal/ExternalTemporalSupervisor.ts
+++ b/src/temporal/ExternalTemporalSupervisor.ts
@@ -1,6 +1,11 @@
 import { EventEmitter } from 'events';
+import { buildExternalConnectionOptions } from './externalConnection';
 import { classifyExternalConnectFailure } from './externalConnectFailure';
-import { probeExternalTemporalHealth, probeExternalTemporalPreflight } from './healthProbe';
+import {
+    probeExternalTemporalHealth,
+    probeExternalTemporalPreflight,
+    probeWorkerTaskQueuePoll,
+} from './healthProbe';
 import { formatSafeForLog } from './secretRedaction';
 import type {
     ExternalConnectError,
@@ -28,6 +33,7 @@ const UNHEALTHY_PROBE_THRESHOLD = 3;
 export interface ExternalTemporalSupervisorOptions {
     preflight?: ExternalPreflightProber;
     probeHealth?: ExternalHealthProber;
+    probeWorkerPoll?: typeof probeWorkerTaskQueuePoll;
     log?: (line: string) => void;
 }
 
@@ -35,6 +41,7 @@ export class ExternalTemporalSupervisor {
     private readonly emitter = new EventEmitter();
     private readonly preflight: ExternalPreflightProber;
     private readonly probeHealth: ExternalHealthProber;
+    private readonly probeWorkerPoll: typeof probeWorkerTaskQueuePoll;
     private readonly log: (line: string) => void;
 
     private state: ExternalTemporalHealthState = 'idle';
@@ -50,6 +57,7 @@ export class ExternalTemporalSupervisor {
     ) {
         this.preflight = options.preflight ?? probeExternalTemporalPreflight;
         this.probeHealth = options.probeHealth ?? probeExternalTemporalHealth;
+        this.probeWorkerPoll = options.probeWorkerPoll ?? probeWorkerTaskQueuePoll;
         this.log = options.log ?? (() => undefined);
     }
 
@@ -127,8 +135,18 @@ export class ExternalTemporalSupervisor {
 
         try {
             await this.preflight({ settings, apiKey });
-            this.transitionTo('ready');
-            this.logExternalState('ready', settings, apiKey);
+            const polling = await this.probeWorkerPoll(
+                this.buildWorkerPollOptions(settings, apiKey)
+            );
+            if (polling) {
+                this.transitionTo('ready');
+            } else {
+                this.transitionTo('unhealthy');
+                this.log(
+                    `[forge.temporal.external] unhealthy windowId=${this.config.windowId} reason=no_worker_poll taskQueue=${settings.taskQueue}`
+                );
+            }
+            this.logExternalState(this.state, settings, apiKey);
             this.startHealthMonitor(settings, apiKey);
         } catch (error) {
             this.failConnect(error, settings, apiKey);
@@ -154,7 +172,11 @@ export class ExternalTemporalSupervisor {
             return;
         }
 
-        const healthy = await this.probeHealth({ settings, apiKey });
+        const serverHealthy = await this.probeHealth({ settings, apiKey });
+        const polling = await this.probeWorkerPoll(
+            this.buildWorkerPollOptions(settings, apiKey)
+        );
+        const healthy = serverHealthy && polling;
 
         if (healthy) {
             this.consecutiveProbeFailures = 0;
@@ -196,6 +218,21 @@ export class ExternalTemporalSupervisor {
                 { knownSecrets: apiKey ? [apiKey] : [] }
             )
         );
+    }
+
+    private buildWorkerPollOptions(
+        settings: ReturnType<ExternalTemporalSupervisorConfig['resolveSettings']>,
+        apiKey: string | undefined
+    ): Parameters<typeof probeWorkerTaskQueuePoll>[0] {
+        return {
+            mode: 'external',
+            address: settings.address ?? '',
+            namespace: settings.namespace ?? '',
+            taskQueue: settings.taskQueue,
+            externalSettings: settings,
+            apiKey,
+            connectionOptions: buildExternalConnectionOptions(settings, apiKey),
+        };
     }
 
     private logExternalState(

--- a/src/temporal/TemporalWorkerSupervisor.test.ts
+++ b/src/temporal/TemporalWorkerSupervisor.test.ts
@@ -1,0 +1,183 @@
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { classifyWorkerStartFailure } from './workerFailureClassification';
+import {
+    TemporalWorkerSupervisor,
+    WorkerReadinessBlockedError,
+} from './TemporalWorkerSupervisor';
+import type { SpawnedChildProcess } from './types';
+
+class FakeChild extends EventEmitter {
+    pid = 5151;
+
+    kill(): void {
+        // no-op for tests
+    }
+}
+
+function createSupervisor(options: {
+    probeResults: boolean[];
+    spawnChild?: () => SpawnedChildProcess;
+    startupTimeoutMs?: number;
+    extensionPath?: string;
+    extensionVersion?: string;
+    isTemporalConnectionReady?: () => boolean;
+    emitReadyOnSpawn?: boolean;
+}) {
+    let probeIndex = 0;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-worker-'));
+    const extensionPath =
+        options.extensionPath ??
+        (() => {
+            const root = path.join(tempDir, 'extension');
+            const entryDir = path.join(root, 'resources', 'workflow', 'worker');
+            fs.mkdirSync(entryDir, { recursive: true });
+            fs.writeFileSync(path.join(entryDir, 'start-worker.js'), 'module.exports = {};\n');
+            return root;
+        })();
+
+    const child = new FakeChild();
+    const supervisor = new TemporalWorkerSupervisor(
+        {
+            windowId: 'window-test',
+            extensionPath,
+            extensionVersion: options.extensionVersion ?? '3.26.0',
+            globalStoragePath: path.join(tempDir, 'storage'),
+            mode: 'managedLocal',
+            namespace: 'forge-local',
+            taskQueue: 'forge-workflows',
+            grpcPort: 7233,
+            isTemporalConnectionReady:
+                options.isTemporalConnectionReady ?? (() => true),
+        },
+        {
+            spawnChild:
+                options.spawnChild ??
+                (() => {
+                    if (options.emitReadyOnSpawn !== false) {
+                        setImmediate(() => {
+                            child.emit(
+                                'stdout',
+                                Buffer.from('FORGE_WORKER_READY:taskQueue=forge-workflows\n')
+                            );
+                        });
+                    }
+                    return child;
+                }),
+            probeTaskQueue: async () => {
+                const result = options.probeResults[probeIndex] ?? false;
+                probeIndex += 1;
+                return result;
+            },
+            startupTimeoutMs: options.startupTimeoutMs ?? 2_000,
+        }
+    );
+
+    return { supervisor, child, tempDir, extensionPath };
+}
+
+describe('classifyWorkerStartFailure', () => {
+    it('classifies repeated crash failures', () => {
+        expect(
+            classifyWorkerStartFailure({
+                repeatedCrash: true,
+            }).remediation
+        ).toBe('crash');
+    });
+});
+
+describe('TemporalWorkerSupervisor', () => {
+    const tempDirs: string[] = [];
+
+    afterEach(() => {
+        for (const dir of tempDirs.splice(0)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('starts in idle and transitions to ready after ready signal and probe', async () => {
+        const { supervisor, tempDir } = createSupervisor({
+            probeResults: [true],
+        });
+        tempDirs.push(tempDir);
+
+        expect(supervisor.getHealthState()).toBe('idle');
+        await supervisor.ensureReady();
+        expect(supervisor.getHealthState()).toBe('ready');
+    });
+
+    it('reports idle when Temporal connection is not ready', async () => {
+        const { supervisor, tempDir } = createSupervisor({
+            probeResults: [],
+            isTemporalConnectionReady: () => false,
+        });
+        tempDirs.push(tempDir);
+
+        await expect(supervisor.ensureReady()).rejects.toBeInstanceOf(
+            WorkerReadinessBlockedError
+        );
+        expect(supervisor.getHealthState()).toBe('idle');
+    });
+
+    it('restarts worker when extension version changes', async () => {
+        const { supervisor, tempDir, extensionPath } = createSupervisor({
+            probeResults: [true, true],
+            extensionVersion: '3.27.0',
+        });
+        tempDirs.push(tempDir);
+
+        const manifestPath = path.join(
+            tempDir,
+            'storage',
+            'temporal',
+            'window-test',
+            'worker-manifest.json'
+        );
+        fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+        fs.writeFileSync(
+            manifestPath,
+            `${JSON.stringify({
+                extensionVersion: '3.26.0',
+                workerEntryPath: path.join(extensionPath, 'resources/workflow/worker/start-worker.js'),
+                pid: 111,
+            })}\n`
+        );
+
+        await supervisor.ensureReady();
+
+        expect(supervisor.getHealthState()).toBe('ready');
+        expect(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).extensionVersion).toBe(
+            '3.27.0'
+        );
+    });
+
+    it('transitions to start_failed when the child exits during startup', async () => {
+        const child = new FakeChild();
+        const { supervisor, tempDir } = createSupervisor({
+            probeResults: [false, false, false],
+            spawnChild: () => child,
+            startupTimeoutMs: 1_500,
+        });
+        tempDirs.push(tempDir);
+
+        const readyPromise = supervisor.ensureReady();
+        child.emit('exit', 1, null);
+
+        await expect(readyPromise).rejects.toBeInstanceOf(WorkerReadinessBlockedError);
+        expect(supervisor.getHealthState()).toBe('start_failed');
+    });
+
+    it('stops gracefully', async () => {
+        const { supervisor, tempDir } = createSupervisor({
+            probeResults: [true],
+        });
+        tempDirs.push(tempDir);
+
+        await supervisor.ensureReady();
+        await supervisor.stop();
+        expect(supervisor.getHealthState()).toBe('stopped');
+    });
+});

--- a/src/temporal/TemporalWorkerSupervisor.ts
+++ b/src/temporal/TemporalWorkerSupervisor.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { classifyWorkerStartFailure } from './workerFailureClassification';
 import { probeWorkerTaskQueuePoll } from './healthProbe';
+import { formatWorkerUpgradeRestartLogLine } from './temporalPresentation';
 import {
     assertWorkerEntryExists,
     buildWorkerSpawnEnv,
@@ -93,6 +94,10 @@ export class TemporalWorkerSupervisor {
 
     getStartError(): WorkerStartError | undefined {
         return this.startError;
+    }
+
+    getWorkerPid(): number | undefined {
+        return this.child?.pid;
     }
 
     onStateChange(listener: (state: WorkerHealthState) => void): () => void {
@@ -198,7 +203,10 @@ export class TemporalWorkerSupervisor {
 
         if (this.upgradeRestartPending) {
             this.log(
-                `[forge.temporal.worker] upgradeRestart windowId=${this.config.windowId} extensionVersion=${this.config.extensionVersion}`
+                formatWorkerUpgradeRestartLogLine({
+                    windowId: this.config.windowId,
+                    extensionVersion: this.config.extensionVersion,
+                })
             );
             this.upgradeRestartPending = false;
         }

--- a/src/temporal/TemporalWorkerSupervisor.ts
+++ b/src/temporal/TemporalWorkerSupervisor.ts
@@ -1,0 +1,492 @@
+import { EventEmitter } from 'events';
+import { classifyWorkerStartFailure } from './workerFailureClassification';
+import { probeWorkerTaskQueuePoll } from './healthProbe';
+import {
+    assertWorkerEntryExists,
+    buildWorkerSpawnEnv,
+    resolveExternalWorkerConnection,
+    resolveManagedLocalWorkerConnection,
+    resolveWorkerEntry,
+    resolveWorkerManifestPath,
+} from './workerLaunch';
+import {
+    readWorkerManifest,
+    workerManifestVersionMismatch,
+    writeWorkerManifest,
+} from './workerManifest';
+import type {
+    ChildProcessSpawner,
+    SpawnedChildProcess,
+    TemporalWorkerSupervisorConfig,
+    WorkerHealthState,
+    WorkerStartError,
+} from './types';
+
+export class WorkerReadinessBlockedError extends Error {
+    readonly remediation: WorkerStartError['remediation'];
+    readonly healthState: WorkerHealthState;
+
+    constructor(startError: WorkerStartError, healthState: WorkerHealthState) {
+        super(startError.message);
+        this.name = 'WorkerReadinessBlockedError';
+        this.remediation = startError.remediation;
+        this.healthState = healthState;
+    }
+}
+
+const STARTUP_TIMEOUT_MS = 60_000;
+const HEALTH_PROBE_INTERVAL_MS = 500;
+const UNHEALTHY_PROBE_THRESHOLD = 3;
+const MAX_RESTART_BACKOFF_MS = 30_000;
+const MAX_CONSECUTIVE_START_FAILURES = 5;
+const WORKER_READY_PREFIX = 'FORGE_WORKER_READY:';
+
+export interface TemporalWorkerSupervisorOptions {
+    spawnChild?: ChildProcessSpawner;
+    probeTaskQueue?: typeof probeWorkerTaskQueuePoll;
+    log?: (line: string) => void;
+    startupTimeoutMs?: number;
+}
+
+export class TemporalWorkerSupervisor {
+    private readonly emitter = new EventEmitter();
+    private readonly spawnChild: ChildProcessSpawner;
+    private readonly probeTaskQueue: typeof probeWorkerTaskQueuePoll;
+    private readonly log: (line: string) => void;
+    private readonly startupTimeoutMs: number;
+    private readonly manifestPath: string;
+
+    private state: WorkerHealthState = 'idle';
+    private startError: WorkerStartError | undefined;
+    private child: SpawnedChildProcess | undefined;
+    private startPromise: Promise<void> | undefined;
+    private consecutiveProbeFailures = 0;
+    private consecutiveStartFailures = 0;
+    private restartAttempt = 0;
+    private restartTimer: NodeJS.Timeout | undefined;
+    private healthMonitorTimer: NodeJS.Timeout | undefined;
+    private stderrBuffer = '';
+    private stdoutBuffer = '';
+    private readySignalReceived = false;
+    private upgradeRestartPending = false;
+
+    constructor(
+        private readonly config: TemporalWorkerSupervisorConfig,
+        options: TemporalWorkerSupervisorOptions = {}
+    ) {
+        this.spawnChild = options.spawnChild ?? defaultSpawnChild;
+        this.probeTaskQueue = options.probeTaskQueue ?? probeWorkerTaskQueuePoll;
+        this.log = options.log ?? (() => undefined);
+        this.startupTimeoutMs = options.startupTimeoutMs ?? STARTUP_TIMEOUT_MS;
+        this.manifestPath = resolveWorkerManifestPath(
+            config.globalStoragePath,
+            config.windowId
+        );
+    }
+
+    getHealthState(): WorkerHealthState {
+        if (!this.config.isTemporalConnectionReady()) {
+            return 'idle';
+        }
+        return this.state;
+    }
+
+    getStartError(): WorkerStartError | undefined {
+        return this.startError;
+    }
+
+    onStateChange(listener: (state: WorkerHealthState) => void): () => void {
+        this.emitter.on('state', listener);
+        return () => {
+            this.emitter.off('state', listener);
+        };
+    }
+
+    async ensureReady(): Promise<void> {
+        if (!this.config.isTemporalConnectionReady()) {
+            this.transitionTo('idle');
+            throw new WorkerReadinessBlockedError(
+                {
+                    remediation: 'asset',
+                    message: 'Forge workflow worker cannot start until Temporal is ready.',
+                },
+                'idle'
+            );
+        }
+
+        const manifest = readWorkerManifest(this.manifestPath);
+        if (workerManifestVersionMismatch(manifest, this.config.extensionVersion)) {
+            this.upgradeRestartPending = true;
+            await this.stopWorkerProcess();
+            this.log(
+                `[forge.temporal.worker] extensionVersionChanged windowId=${this.config.windowId} previous=${manifest?.extensionVersion} current=${this.config.extensionVersion}`
+            );
+        }
+
+        if (this.state === 'ready') {
+            return;
+        }
+
+        if (this.state === 'start_failed') {
+            throw new WorkerReadinessBlockedError(
+                this.startError ?? {
+                    remediation: 'asset',
+                    message: 'Forge workflow worker failed to start.',
+                },
+                this.state
+            );
+        }
+
+        if (!this.startPromise) {
+            this.startPromise = this.startWorker();
+        }
+
+        try {
+            await this.startPromise;
+        } catch (error) {
+            if (error instanceof WorkerReadinessBlockedError) {
+                throw error;
+            }
+            throw error;
+        }
+
+        const finalState = this.getHealthState();
+        if (finalState !== 'ready') {
+            throw new WorkerReadinessBlockedError(
+                this.startError ?? {
+                    remediation: 'asset',
+                    message: 'Forge workflow worker is not ready.',
+                },
+                finalState
+            );
+        }
+    }
+
+    async stop(): Promise<void> {
+        this.clearRestartTimer();
+        this.clearHealthMonitor();
+        await this.stopWorkerProcess();
+        this.startPromise = undefined;
+        this.consecutiveProbeFailures = 0;
+        this.restartAttempt = 0;
+        this.consecutiveStartFailures = 0;
+        this.stderrBuffer = '';
+        this.stdoutBuffer = '';
+        this.readySignalReceived = false;
+        this.upgradeRestartPending = false;
+
+        if (this.state !== 'start_failed') {
+            this.transitionTo('stopped');
+        }
+    }
+
+    private async stopWorkerProcess(): Promise<void> {
+        const child = this.child;
+        this.child = undefined;
+        if (child) {
+            child.kill('SIGTERM');
+        }
+    }
+
+    private async startWorker(): Promise<void> {
+        this.startError = undefined;
+        this.stderrBuffer = '';
+        this.stdoutBuffer = '';
+        this.readySignalReceived = false;
+        this.consecutiveProbeFailures = 0;
+        this.transitionTo(this.restartAttempt > 0 || this.upgradeRestartPending ? 'restarting' : 'starting');
+
+        if (this.upgradeRestartPending) {
+            this.log(
+                `[forge.temporal.worker] upgradeRestart windowId=${this.config.windowId} extensionVersion=${this.config.extensionVersion}`
+            );
+            this.upgradeRestartPending = false;
+        }
+
+        try {
+            assertWorkerEntryExists(this.config.extensionPath);
+        } catch (error) {
+            this.failStart({
+                spawnError: error instanceof Error ? error : new Error(String(error)),
+            });
+            throw new WorkerReadinessBlockedError(this.startError!, this.state);
+        }
+
+        const connection = await this.resolveConnection();
+        const entryPath = resolveWorkerEntry(this.config.extensionPath);
+        const env = buildWorkerSpawnEnv(this.config, connection);
+
+        this.log(
+            `[forge.temporal.worker] starting windowId=${this.config.windowId} mode=${this.config.mode} taskQueue=${connection.taskQueue} namespace=${connection.namespace} extensionVersion=${this.config.extensionVersion}`
+        );
+
+        const child = this.spawnChild({
+            command: process.execPath,
+            args: [entryPath],
+            cwd: this.config.extensionPath,
+            env,
+        });
+        this.child = child;
+
+        child.on('stdout', (chunk) => {
+            const text = chunk.toString();
+            this.stdoutBuffer += text;
+            if (text.includes(WORKER_READY_PREFIX)) {
+                this.readySignalReceived = true;
+            }
+        });
+
+        child.on('stderr', (chunk) => {
+            this.stderrBuffer += chunk.toString();
+        });
+
+        child.on('error', (spawnError) => {
+            this.failStart({ spawnError, stderr: this.stderrBuffer });
+        });
+
+        child.on('exit', (code) => {
+            const wasReady = this.state === 'ready' || this.state === 'unhealthy';
+            this.clearHealthMonitor();
+            this.child = undefined;
+            this.startPromise = undefined;
+
+            this.log(
+                `[forge.temporal.worker] process exited windowId=${this.config.windowId} exitCode=${code ?? 'null'} pid=${child.pid ?? 'null'}`
+            );
+
+            if (this.state === 'starting' || this.state === 'restarting') {
+                this.failStart({ exitCode: code, stderr: this.stderrBuffer });
+                return;
+            }
+
+            if (wasReady) {
+                this.scheduleRestartAfterCrash(code);
+            }
+        });
+
+        const deadline = Date.now() + this.startupTimeoutMs;
+
+        while (Date.now() < deadline) {
+            if (this.state === 'start_failed' || this.state === 'stopped') {
+                throw new WorkerReadinessBlockedError(this.startError!, this.state);
+            }
+
+            if (this.readySignalReceived) {
+                const polling = await this.probeTaskQueue({
+                    mode: connection.mode,
+                    address: connection.address,
+                    namespace: connection.namespace,
+                    taskQueue: connection.taskQueue,
+                    externalSettings: connection.externalSettings,
+                    apiKey: connection.apiKey,
+                    connectionOptions: connection.connectionOptions,
+                });
+
+                if (polling) {
+                    this.consecutiveStartFailures = 0;
+                    this.restartAttempt = 0;
+                    writeWorkerManifest(this.manifestPath, {
+                        extensionVersion: this.config.extensionVersion,
+                        workerEntryPath: entryPath,
+                        pid: child.pid ?? 0,
+                    });
+                    this.transitionTo('ready');
+                    this.log(
+                        `[forge.temporal.worker] ready windowId=${this.config.windowId} taskQueue=${connection.taskQueue} namespace=${connection.namespace} mode=${this.config.mode} extensionVersion=${this.config.extensionVersion} pid=${child.pid ?? 'null'}`
+                    );
+                    this.startHealthMonitor(connection);
+                    return;
+                }
+            }
+
+            await delay(HEALTH_PROBE_INTERVAL_MS);
+        }
+
+        this.failStart({
+            stderr: this.stderrBuffer,
+            exitCode: null,
+        });
+        child.kill('SIGTERM');
+        throw new WorkerReadinessBlockedError(this.startError!, this.state);
+    }
+
+    private async resolveConnection(): Promise<{
+        mode: 'managedLocal' | 'external';
+        address: string;
+        namespace: string;
+        taskQueue: string;
+        externalSettings?: import('./externalSettings').ResolvedExternalSettings;
+        apiKey?: string;
+        connectionOptions?: import('@temporalio/client').ConnectionOptions;
+    }> {
+        if (this.config.mode === 'external') {
+            const settings = this.config.resolveExternalSettings?.();
+            if (!settings?.address || !settings.namespace) {
+                throw new Error('External Temporal settings are incomplete for worker spawn.');
+            }
+            const apiKey = (await this.config.resolveApiKey?.()) ?? undefined;
+            return resolveExternalWorkerConnection(settings, apiKey);
+        }
+
+        if (this.config.grpcPort === undefined) {
+            throw new Error('Managed-local gRPC port is required for worker spawn.');
+        }
+
+        return resolveManagedLocalWorkerConnection({
+            grpcPort: this.config.grpcPort,
+            namespace: this.config.namespace,
+            taskQueue: this.config.taskQueue,
+        });
+    }
+
+    private scheduleRestartAfterCrash(exitCode: number | null): void {
+        this.consecutiveStartFailures += 1;
+        if (this.consecutiveStartFailures >= MAX_CONSECUTIVE_START_FAILURES) {
+            this.failStart({
+                exitCode,
+                stderr: this.stderrBuffer,
+                repeatedCrash: true,
+            });
+            return;
+        }
+
+        this.restartAttempt += 1;
+        const backoffMs = Math.min(
+            MAX_RESTART_BACKOFF_MS,
+            HEALTH_PROBE_INTERVAL_MS * 2 ** this.restartAttempt
+        );
+        this.transitionTo('restarting');
+        this.log(
+            `[forge.temporal.worker] restarting windowId=${this.config.windowId} attempt=${this.restartAttempt} backoffMs=${backoffMs}`
+        );
+
+        this.clearRestartTimer();
+        this.restartTimer = setTimeout(() => {
+            this.startPromise = this.startWorker();
+            void this.startPromise.catch(() => undefined);
+        }, backoffMs);
+    }
+
+    private clearRestartTimer(): void {
+        if (this.restartTimer) {
+            clearTimeout(this.restartTimer);
+            this.restartTimer = undefined;
+        }
+    }
+
+    private startHealthMonitor(connection: {
+        mode: 'managedLocal' | 'external';
+        address: string;
+        namespace: string;
+        taskQueue: string;
+        externalSettings?: import('./externalSettings').ResolvedExternalSettings;
+        apiKey?: string;
+        connectionOptions?: import('@temporalio/client').ConnectionOptions;
+    }): void {
+        this.clearHealthMonitor();
+        this.healthMonitorTimer = setInterval(() => {
+            void this.runHealthMonitorTick(connection);
+        }, HEALTH_PROBE_INTERVAL_MS);
+    }
+
+    private async runHealthMonitorTick(connection: {
+        mode: 'managedLocal' | 'external';
+        address: string;
+        namespace: string;
+        taskQueue: string;
+        externalSettings?: import('./externalSettings').ResolvedExternalSettings;
+        apiKey?: string;
+        connectionOptions?: import('@temporalio/client').ConnectionOptions;
+    }): Promise<void> {
+        if (this.state !== 'ready' && this.state !== 'unhealthy') {
+            return;
+        }
+
+        const polling = await this.probeTaskQueue({
+            mode: connection.mode,
+            address: connection.address,
+            namespace: connection.namespace,
+            taskQueue: connection.taskQueue,
+            externalSettings: connection.externalSettings,
+            apiKey: connection.apiKey,
+            connectionOptions: connection.connectionOptions,
+        });
+
+        if (polling) {
+            this.consecutiveProbeFailures = 0;
+            if (this.state === 'unhealthy') {
+                this.transitionTo('ready');
+            }
+            return;
+        }
+
+        this.consecutiveProbeFailures += 1;
+        if (
+            this.consecutiveProbeFailures >= UNHEALTHY_PROBE_THRESHOLD &&
+            this.state === 'ready'
+        ) {
+            this.transitionTo('unhealthy');
+            this.log(
+                `[forge.temporal.worker] unhealthy windowId=${this.config.windowId} taskQueue=${connection.taskQueue}`
+            );
+        }
+    }
+
+    private clearHealthMonitor(): void {
+        if (this.healthMonitorTimer) {
+            clearInterval(this.healthMonitorTimer);
+            this.healthMonitorTimer = undefined;
+        }
+    }
+
+    private failStart(input: {
+        spawnError?: Error;
+        exitCode?: number | null;
+        stderr?: string;
+        repeatedCrash?: boolean;
+    }): void {
+        const classified = classifyWorkerStartFailure(input);
+        this.startError = {
+            remediation: classified.remediation,
+            message: classified.message,
+            exitCode: input.exitCode ?? undefined,
+        };
+        this.clearHealthMonitor();
+        this.clearRestartTimer();
+        void this.stopWorkerProcess();
+        this.startPromise = undefined;
+        this.transitionTo('start_failed');
+        this.log(
+            `[forge.temporal.worker] start_failed windowId=${this.config.windowId} remediation=${classified.remediation} exitCode=${input.exitCode ?? 'null'}`
+        );
+    }
+
+    private transitionTo(next: WorkerHealthState): void {
+        if (this.state === next) {
+            return;
+        }
+        this.state = next;
+        this.emitter.emit('state', this.getHealthState());
+    }
+}
+
+function defaultSpawnChild(options: {
+    command: string;
+    args: string[];
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+}): SpawnedChildProcess {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { spawn } = require('child_process') as typeof import('child_process');
+    return spawn(options.command, options.args, {
+        cwd: options.cwd,
+        env: options.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}

--- a/src/temporal/healthProbe.ts
+++ b/src/temporal/healthProbe.ts
@@ -1,6 +1,7 @@
 import { Connection } from '@temporalio/client';
 import { buildExternalConnectionOptions } from './externalConnection';
 import type { ResolvedExternalSettings } from './externalSettings';
+import type { TemporalMode } from './temporalSettings';
 
 export async function probeManagedLocalTemporalHealth(options: {
     address: string;
@@ -55,5 +56,43 @@ export async function probeExternalTemporalHealth(options: {
         return true;
     } catch {
         return false;
+    }
+}
+
+export async function probeWorkerTaskQueuePoll(options: {
+    mode: TemporalMode;
+    address: string;
+    namespace: string;
+    taskQueue: string;
+    externalSettings?: ResolvedExternalSettings;
+    apiKey?: string;
+    connectionOptions?: import('@temporalio/client').ConnectionOptions;
+}): Promise<boolean> {
+    let connection: Connection | undefined;
+    try {
+        if (options.mode === 'external' && options.externalSettings) {
+            const connectionOptions =
+                options.connectionOptions ??
+                buildExternalConnectionOptions(options.externalSettings, options.apiKey);
+            connection = await Connection.connect(connectionOptions);
+        } else {
+            connection = await Connection.connect({
+                address: options.address,
+            });
+        }
+
+        const response = await connection.workflowService.describeTaskQueue({
+            namespace: options.namespace,
+            taskQueue: { name: options.taskQueue },
+            taskQueueType: 1,
+            reportPollers: true,
+        });
+
+        const pollers = response.pollers ?? [];
+        return pollers.length > 0;
+    } catch {
+        return false;
+    } finally {
+        await connection?.close().catch(() => undefined);
     }
 }

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -89,9 +89,12 @@ export {
     formatReadyNotification,
     formatStartFailedNotification,
     formatWorkflowBlockedNotification,
+    formatWorkerBlockedNotification,
+    formatWorkerReadyNotification,
     formatWorkerStartFailedNotification,
     formatWorkerStateTransitionLogLine,
     formatWorkerStatusBarSegment,
+    formatWorkerUpgradeRestartLogLine,
 } from './temporalPresentation';
 export {
     TEMPORAL_OUTPUT_CHANNEL_NAME,

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -3,6 +3,10 @@ export {
     TemporalReadinessBlockedError,
 } from './TemporalLocalSupervisor';
 export {
+    TemporalWorkerSupervisor,
+    WorkerReadinessBlockedError,
+} from './TemporalWorkerSupervisor';
+export {
     ExternalTemporalSupervisor,
     ExternalReadinessBlockedError,
 } from './ExternalTemporalSupervisor';
@@ -59,6 +63,19 @@ export {
     buildManagedLocalGrpcAddress,
     resolveManagedLocalDevServerEntry,
 } from './devServerLaunch';
+export {
+    WORKER_ENTRY,
+    assertWorkerEntryExists,
+    buildWorkerSpawnEnv,
+    resolveWorkerEntry,
+    resolveWorkerManifestPath,
+} from './workerLaunch';
+export {
+    readWorkerManifest,
+    writeWorkerManifest,
+    workerManifestVersionMismatch,
+} from './workerManifest';
+export { classifyWorkerStartFailure } from './workerFailureClassification';
 export { classifyStartFailure } from './failureClassification';
 export { classifyExternalConnectFailure } from './externalConnectFailure';
 export {
@@ -72,22 +89,29 @@ export {
     formatReadyNotification,
     formatStartFailedNotification,
     formatWorkflowBlockedNotification,
+    formatWorkerStartFailedNotification,
+    formatWorkerStateTransitionLogLine,
+    formatWorkerStatusBarSegment,
 } from './temporalPresentation';
 export {
     TEMPORAL_OUTPUT_CHANNEL_NAME,
     createTemporalOutputChannel,
     notifyWorkflowBlockedByTemporal,
+    notifyWorkflowBlockedByWorker,
     registerExternalTemporalHealthSurfaces,
     registerManagedLocalTemporalHealthSurfaces,
+    registerWorkerHealthSurfaces,
 } from './temporalHealthSurfaces';
 export {
     probeExternalTemporalHealth,
     probeExternalTemporalPreflight,
     probeManagedLocalTemporalHealth,
+    probeWorkerTaskQueuePoll,
 } from './healthProbe';
 export {
     getExternalTemporalSupervisor,
     getTemporalLocalSupervisor,
+    getTemporalWorkerSupervisor,
     registerTemporalLocalSupervisor,
     shutdownTemporalLocalSupervisor,
 } from './temporalWindowRegistry';
@@ -106,4 +130,8 @@ export type {
     ManagedLocalSupervisorConfig,
     SpawnedChildProcess,
     StartFailureRemediation,
+    TemporalWorkerSupervisorConfig,
+    WorkerHealthState,
+    WorkerStartError,
+    WorkerStartFailureRemediation,
 } from './types';

--- a/src/temporal/temporalHealthSurfaces.test.ts
+++ b/src/temporal/temporalHealthSurfaces.test.ts
@@ -1,0 +1,182 @@
+import { EventEmitter } from 'events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import {
+    registerManagedLocalTemporalHealthSurfaces,
+    registerWorkerHealthSurfaces,
+} from './temporalHealthSurfaces';
+import type {
+    ManagedLocalSupervisorConfig,
+    TemporalWorkerSupervisorConfig,
+    WorkerHealthState,
+    WorkerStartError,
+} from './types';
+
+class MockWorkerSupervisor extends EventEmitter {
+    private state: WorkerHealthState = 'idle';
+    private startError: WorkerStartError | undefined;
+    private pid: number | undefined;
+
+    constructor(initialState: WorkerHealthState = 'idle') {
+        super();
+        this.state = initialState;
+    }
+
+    getHealthState(): WorkerHealthState {
+        return this.state;
+    }
+
+    getStartError(): WorkerStartError | undefined {
+        return this.startError;
+    }
+
+    getWorkerPid(): number | undefined {
+        return this.pid;
+    }
+
+    onStateChange(listener: (state: WorkerHealthState) => void): () => void {
+        this.on('state', listener);
+        return () => {
+            this.off('state', listener);
+        };
+    }
+
+    emitState(state: WorkerHealthState, options?: { startError?: WorkerStartError; pid?: number }): void {
+        this.state = state;
+        this.startError = options?.startError;
+        this.pid = options?.pid;
+        this.emit('state', state);
+    }
+}
+
+class MockLocalSupervisor extends EventEmitter {
+    getHealthState() {
+        return 'ready' as const;
+    }
+
+    getStartError() {
+        return undefined;
+    }
+
+    onStateChange(listener: (state: 'ready') => void): () => void {
+        this.on('state', listener);
+        return () => {
+            this.off('state', listener);
+        };
+    }
+}
+
+describe('temporalHealthSurfaces worker registration', () => {
+    const subscriptions: Array<{ dispose: () => void }> = [];
+    const context = {
+        subscriptions,
+        extensionPath: '/extension',
+        globalStorageUri: { fsPath: '/storage' },
+    } as unknown as import('vscode').ExtensionContext;
+
+    const workerConfig: TemporalWorkerSupervisorConfig = {
+        windowId: 'window-test',
+        extensionPath: '/extension',
+        extensionVersion: '3.26.0',
+        globalStoragePath: '/storage',
+        mode: 'managedLocal',
+        namespace: 'forge-local',
+        taskQueue: 'forge-workflows',
+        grpcPort: 7233,
+        isTemporalConnectionReady: () => true,
+    };
+
+    const managedLocalConfig: ManagedLocalSupervisorConfig = {
+        windowId: 'window-test',
+        extensionPath: '/extension',
+        globalStoragePath: '/storage',
+        grpcPort: 7233,
+        uiPort: 8233,
+        persistencePath: '/storage/temporal/window-test',
+        persistencePathDisplay: '/storage/temporal/window-test',
+        namespace: 'forge-local',
+        taskQueue: 'forge-workflows',
+    };
+
+    let outputChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        subscriptions.splice(0);
+        vi.clearAllMocks();
+        outputChannel = { appendLine: vi.fn() };
+    });
+
+    it('shows ready notification only once per session', () => {
+        const supervisor = new MockWorkerSupervisor('starting');
+        registerWorkerHealthSurfaces(context, supervisor as never, workerConfig, outputChannel as never);
+
+        supervisor.emitState('ready', { pid: 5151 });
+        supervisor.emitState('unhealthy');
+        supervisor.emitState('ready', { pid: 5151 });
+
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+            'Forge workflow worker is ready.'
+        );
+    });
+
+    it('logs worker state transitions with contract prefix and fields', () => {
+        const supervisor = new MockWorkerSupervisor('starting');
+        registerWorkerHealthSurfaces(context, supervisor as never, workerConfig, outputChannel as never);
+
+        supervisor.emitState('start_failed', {
+            startError: {
+                remediation: 'crash',
+                message: 'worker crashed',
+                exitCode: 1,
+            },
+        });
+
+        expect(outputChannel.appendLine).toHaveBeenCalledWith(
+            '[forge.temporal.worker] state=start_failed windowId=window-test taskQueue=forge-workflows namespace=forge-local mode=managedLocal extensionVersion=3.26.0 exitCode=1'
+        );
+    });
+
+    it('shows error notification on worker start_failed', () => {
+        const supervisor = new MockWorkerSupervisor('start_failed');
+        registerWorkerHealthSurfaces(context, supervisor as never, workerConfig, outputChannel as never);
+
+        supervisor.emitState('start_failed', {
+            startError: {
+                remediation: 'asset',
+                message: 'missing worker assets',
+            },
+        });
+
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            'Forge could not start the workflow worker — worker assets are missing from the extension package. Reinstall Forge Studio.'
+        );
+    });
+
+    it('updates status bar with compound Temporal and worker labels', () => {
+        const localSupervisor = new MockLocalSupervisor();
+        const workerSupervisor = new MockWorkerSupervisor('idle');
+        const statusBarItem = {
+            text: '',
+            tooltip: '',
+            show: vi.fn(),
+            hide: vi.fn(),
+            dispose: vi.fn(),
+        };
+
+        vi.mocked(vscode.window.createStatusBarItem).mockReturnValueOnce(statusBarItem as never);
+
+        registerManagedLocalTemporalHealthSurfaces(
+            context,
+            localSupervisor as never,
+            managedLocalConfig,
+            managedLocalConfig.persistencePathDisplay,
+            outputChannel as never
+        );
+        registerWorkerHealthSurfaces(context, workerSupervisor as never, workerConfig, outputChannel as never);
+
+        workerSupervisor.emitState('ready', { pid: 5151 });
+
+        expect(statusBarItem.text).toBe('$(pulse) Temporal: ready · Worker: ready');
+    });
+});

--- a/src/temporal/temporalHealthSurfaces.ts
+++ b/src/temporal/temporalHealthSurfaces.ts
@@ -14,6 +14,8 @@ import {
     formatReadyNotification,
     formatStartFailedNotification,
     formatStateTransitionLogLine,
+    formatWorkerBlockedNotification,
+    formatWorkerReadyNotification,
     formatWorkerStartFailedNotification,
     formatWorkerStateTransitionLogLine,
     formatWorkflowBlockedNotification,
@@ -37,6 +39,7 @@ let workerPresentationConfig: TemporalWorkerSupervisorConfig | undefined;
 let managedLocalState: ManagedLocalHealthState = 'idle';
 let externalState: ExternalTemporalHealthState = 'idle';
 let workerState: WorkerHealthState = 'idle';
+let workerReadyNotifiedThisSession = false;
 let statusBarMode: 'managedLocal' | 'external' = 'managedLocal';
 
 export function createTemporalOutputChannel(
@@ -52,9 +55,7 @@ export function notifyWorkflowBlockedByTemporal(): void {
 }
 
 export function notifyWorkflowBlockedByWorker(): void {
-    void vscode.window.showWarningMessage(
-        'Workflow runs are blocked until the Forge worker is ready. See Forge Temporal output for details.'
-    );
+    void vscode.window.showWarningMessage(formatWorkerBlockedNotification());
 }
 
 export function registerManagedLocalTemporalHealthSurfaces(
@@ -190,6 +191,7 @@ function logWorkerStateTransition(
     }
 
     const startError = supervisor.getStartError();
+    const pid = supervisor.getWorkerPid();
     outputChannel.appendLine(
         formatWorkerStateTransitionLogLine(state, {
             windowId: workerPresentationConfig.windowId,
@@ -197,6 +199,7 @@ function logWorkerStateTransition(
             namespace: workerPresentationConfig.namespace,
             mode: workerPresentationConfig.mode,
             extensionVersion: workerPresentationConfig.extensionVersion,
+            pid,
             exitCode: startError?.exitCode,
         })
     );
@@ -206,6 +209,15 @@ function notifyWorkerForState(
     state: WorkerHealthState,
     supervisor: TemporalWorkerSupervisor
 ): void {
+    if (state === 'ready') {
+        if (workerReadyNotifiedThisSession) {
+            return;
+        }
+        workerReadyNotifiedThisSession = true;
+        void vscode.window.showInformationMessage(formatWorkerReadyNotification());
+        return;
+    }
+
     if (state === 'start_failed') {
         const startError = supervisor.getStartError();
         if (!startError) {

--- a/src/temporal/temporalHealthSurfaces.ts
+++ b/src/temporal/temporalHealthSurfaces.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ExternalTemporalSupervisor } from './ExternalTemporalSupervisor';
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
+import { TemporalWorkerSupervisor } from './TemporalWorkerSupervisor';
 import {
     formatExternalConnectFailedNotification,
     formatExternalReadyNotification,
@@ -13,6 +14,8 @@ import {
     formatReadyNotification,
     formatStartFailedNotification,
     formatStateTransitionLogLine,
+    formatWorkerStartFailedNotification,
+    formatWorkerStateTransitionLogLine,
     formatWorkflowBlockedNotification,
 } from './temporalPresentation';
 import type { ResolvedExternalSettings } from './externalSettings';
@@ -21,6 +24,8 @@ import type {
     ExternalTemporalSupervisorConfig,
     ManagedLocalHealthState,
     ManagedLocalSupervisorConfig,
+    TemporalWorkerSupervisorConfig,
+    WorkerHealthState,
 } from './types';
 
 export const TEMPORAL_OUTPUT_CHANNEL_NAME = 'Forge Temporal';
@@ -28,6 +33,11 @@ export const TEMPORAL_OUTPUT_CHANNEL_NAME = 'Forge Temporal';
 let statusBarItem: vscode.StatusBarItem | undefined;
 let presentationConfig: ManagedLocalSupervisorConfig | undefined;
 let persistencePathDisplay: string | undefined;
+let workerPresentationConfig: TemporalWorkerSupervisorConfig | undefined;
+let managedLocalState: ManagedLocalHealthState = 'idle';
+let externalState: ExternalTemporalHealthState = 'idle';
+let workerState: WorkerHealthState = 'idle';
+let statusBarMode: 'managedLocal' | 'external' = 'managedLocal';
 
 export function createTemporalOutputChannel(
     context: vscode.ExtensionContext
@@ -41,6 +51,12 @@ export function notifyWorkflowBlockedByTemporal(): void {
     void vscode.window.showWarningMessage(formatWorkflowBlockedNotification());
 }
 
+export function notifyWorkflowBlockedByWorker(): void {
+    void vscode.window.showWarningMessage(
+        'Workflow runs are blocked until the Forge worker is ready. See Forge Temporal output for details.'
+    );
+}
+
 export function registerManagedLocalTemporalHealthSurfaces(
     context: vscode.ExtensionContext,
     supervisor: TemporalLocalSupervisor,
@@ -50,14 +66,16 @@ export function registerManagedLocalTemporalHealthSurfaces(
 ): void {
     presentationConfig = config;
     persistencePathDisplay = persistencePathForDisplay;
+    statusBarMode = 'managedLocal';
 
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
     context.subscriptions.push(statusBarItem);
 
     const applyState = (state: ManagedLocalHealthState) => {
-        updateStatusBar(state);
-        logStateTransition(state, supervisor, outputChannel);
-        notifyForState(state, supervisor);
+        managedLocalState = state;
+        updateStatusBar();
+        logManagedLocalStateTransition(state, supervisor, outputChannel);
+        notifyManagedLocalForState(state, supervisor);
     };
 
     applyState(supervisor.getHealthState());
@@ -68,21 +86,52 @@ export function registerManagedLocalTemporalHealthSurfaces(
     context.subscriptions.push({ dispose: unsubscribe });
 }
 
-function updateStatusBar(state: ManagedLocalHealthState): void {
-    if (!statusBarItem || !presentationConfig || !persistencePathDisplay) {
+export function registerWorkerHealthSurfaces(
+    context: vscode.ExtensionContext,
+    supervisor: TemporalWorkerSupervisor,
+    config: TemporalWorkerSupervisorConfig,
+    outputChannel: vscode.OutputChannel
+): void {
+    workerPresentationConfig = config;
+
+    const applyState = (state: WorkerHealthState) => {
+        workerState = state;
+        updateStatusBar();
+        logWorkerStateTransition(state, supervisor, outputChannel);
+        notifyWorkerForState(state, supervisor);
+    };
+
+    applyState(supervisor.getHealthState());
+
+    const unsubscribe = supervisor.onStateChange((state) => {
+        applyState(state);
+    });
+    context.subscriptions.push({ dispose: unsubscribe });
+}
+
+function updateStatusBar(): void {
+    if (!statusBarItem) {
         return;
     }
 
-    statusBarItem.text = formatManagedLocalStatusBarLabel(state);
-    statusBarItem.tooltip = formatManagedLocalStatusBarTooltip({
-        grpcPort: presentationConfig.grpcPort,
-        namespace: presentationConfig.namespace,
-        persistencePathDisplay,
-    });
+    if (statusBarMode === 'managedLocal') {
+        if (!presentationConfig || !persistencePathDisplay) {
+            return;
+        }
+        statusBarItem.text = formatManagedLocalStatusBarLabel(managedLocalState, workerState);
+        statusBarItem.tooltip = formatManagedLocalStatusBarTooltip({
+            grpcPort: presentationConfig.grpcPort,
+            namespace: presentationConfig.namespace,
+            persistencePathDisplay,
+        });
+    } else {
+        statusBarItem.text = formatExternalStatusBarLabel(externalState, workerState);
+    }
+
     statusBarItem.show();
 }
 
-function logStateTransition(
+function logManagedLocalStateTransition(
     state: ManagedLocalHealthState,
     supervisor: TemporalLocalSupervisor,
     outputChannel: vscode.OutputChannel
@@ -103,7 +152,7 @@ function logStateTransition(
     );
 }
 
-function notifyForState(
+function notifyManagedLocalForState(
     state: ManagedLocalHealthState,
     supervisor: TemporalLocalSupervisor
 ): void {
@@ -131,6 +180,43 @@ function notifyForState(
     }
 }
 
+function logWorkerStateTransition(
+    state: WorkerHealthState,
+    supervisor: TemporalWorkerSupervisor,
+    outputChannel: vscode.OutputChannel
+): void {
+    if (!workerPresentationConfig) {
+        return;
+    }
+
+    const startError = supervisor.getStartError();
+    outputChannel.appendLine(
+        formatWorkerStateTransitionLogLine(state, {
+            windowId: workerPresentationConfig.windowId,
+            taskQueue: workerPresentationConfig.taskQueue,
+            namespace: workerPresentationConfig.namespace,
+            mode: workerPresentationConfig.mode,
+            extensionVersion: workerPresentationConfig.extensionVersion,
+            exitCode: startError?.exitCode,
+        })
+    );
+}
+
+function notifyWorkerForState(
+    state: WorkerHealthState,
+    supervisor: TemporalWorkerSupervisor
+): void {
+    if (state === 'start_failed') {
+        const startError = supervisor.getStartError();
+        if (!startError) {
+            return;
+        }
+        void vscode.window.showErrorMessage(
+            formatWorkerStartFailedNotification(startError.remediation)
+        );
+    }
+}
+
 export function registerExternalTemporalHealthSurfaces(
     context: vscode.ExtensionContext,
     supervisor: ExternalTemporalSupervisor,
@@ -138,22 +224,18 @@ export function registerExternalTemporalHealthSurfaces(
     resolveSettings: () => ResolvedExternalSettings,
     outputChannel: vscode.OutputChannel
 ): void {
-    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    statusBarMode = 'external';
+
+    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
     context.subscriptions.push(statusBarItem);
 
     const applyState = (state: ExternalTemporalHealthState) => {
+        externalState = state;
+        updateStatusBar();
+
         const settings = resolveSettings();
         const address = settings.address ?? 'unknown';
         const namespace = settings.namespace ?? 'unknown';
-
-        statusBarItem.text = formatExternalStatusBarLabel(state);
-        statusBarItem.tooltip = formatExternalStatusBarTooltip({
-            address,
-            namespace,
-            authMode: settings.authMode,
-            tlsEnabled: settings.tlsEnabled,
-        });
-        statusBarItem.show();
 
         const connectError = supervisor.getConnectError();
         outputChannel.appendLine(

--- a/src/temporal/temporalPresentation.test.ts
+++ b/src/temporal/temporalPresentation.test.ts
@@ -8,6 +8,12 @@ import {
     formatReadyNotification,
     formatStartFailedNotification,
     formatWorkflowBlockedNotification,
+    formatWorkerBlockedNotification,
+    formatWorkerReadyNotification,
+    formatWorkerStartFailedNotification,
+    formatWorkerStatusBarSegment,
+    formatWorkerStateTransitionLogLine,
+    formatWorkerUpgradeRestartLogLine,
 } from './temporalPresentation';
 import type { ManagedLocalHealthState } from './types';
 
@@ -101,5 +107,73 @@ describe('temporalPresentation', () => {
         expect(formatExternalReadyNotification('forge-ns', 'host:7233')).toBe(
             'Forge Temporal ready — connected to forge-ns at host:7233.'
         );
+    });
+
+    describe('formatWorkerStatusBarSegment', () => {
+        it('maps worker health states to contract labels', () => {
+            expect(formatWorkerStatusBarSegment('starting')).toBe('Worker: starting…');
+            expect(formatWorkerStatusBarSegment('ready')).toBe('Worker: ready');
+            expect(formatWorkerStatusBarSegment('start_failed')).toBe('Worker: failed');
+        });
+    });
+
+    describe('formatManagedLocalStatusBarLabel with worker segment', () => {
+        it('combines Temporal and worker segments', () => {
+            expect(formatManagedLocalStatusBarLabel('ready', 'ready')).toBe(
+                '$(pulse) Temporal: ready · Worker: ready'
+            );
+        });
+    });
+
+    describe('formatWorkerStartFailedNotification', () => {
+        it('uses asset remediation copy', () => {
+            expect(formatWorkerStartFailedNotification('asset')).toBe(
+                'Forge could not start the workflow worker — worker assets are missing from the extension package. Reinstall Forge Studio.'
+            );
+        });
+
+        it('uses crash remediation copy', () => {
+            expect(formatWorkerStartFailedNotification('crash')).toBe(
+                'Forge workflow worker stopped unexpectedly. See Forge Temporal output. Workflow runs are blocked until the worker is healthy.'
+            );
+        });
+    });
+
+    it('uses worker blocked notification copy from contract', () => {
+        expect(formatWorkerBlockedNotification()).toBe(
+            'Workflow runs are blocked until the Forge worker is ready. See Forge Temporal output for details.'
+        );
+    });
+
+    it('uses worker ready notification copy', () => {
+        expect(formatWorkerReadyNotification()).toBe('Forge workflow worker is ready.');
+    });
+
+    it('uses worker upgrade restart output copy from contract', () => {
+        expect(
+            formatWorkerUpgradeRestartLogLine({
+                windowId: 'window-1',
+                extensionVersion: '3.27.0',
+            })
+        ).toBe(
+            '[forge.temporal.worker] Forge updated the workflow worker for this window. windowId=window-1 extensionVersion=3.27.0'
+        );
+    });
+
+    describe('formatWorkerStateTransitionLogLine', () => {
+        it('includes contract fields and pid when provided', () => {
+            expect(
+                formatWorkerStateTransitionLogLine('ready', {
+                    windowId: 'window-1',
+                    taskQueue: 'forge-workflows',
+                    namespace: 'forge-local',
+                    mode: 'managedLocal',
+                    extensionVersion: '3.26.0',
+                    pid: 5151,
+                })
+            ).toBe(
+                '[forge.temporal.worker] state=ready windowId=window-1 taskQueue=forge-workflows namespace=forge-local mode=managedLocal extensionVersion=3.26.0 pid=5151'
+            );
+        });
     });
 });

--- a/src/temporal/temporalPresentation.ts
+++ b/src/temporal/temporalPresentation.ts
@@ -211,6 +211,10 @@ export interface WorkerPresentationContext {
     exitCode?: number;
 }
 
+export function formatWorkerReadyNotification(): string {
+    return 'Forge workflow worker is ready.';
+}
+
 export function formatWorkerStartFailedNotification(
     remediation: WorkerStartFailureRemediation
 ): string {
@@ -230,8 +234,10 @@ export function formatWorkerBlockedNotification(): string {
     return 'Workflow runs are blocked until the Forge worker is ready. See Forge Temporal output for details.';
 }
 
-export function formatWorkerUpgradeRestartLogLine(context: Pick<WorkerPresentationContext, 'windowId' | 'extensionVersion'>): string {
-    return `[forge.temporal.worker] upgradeRestart windowId=${context.windowId} extensionVersion=${context.extensionVersion}`;
+export function formatWorkerUpgradeRestartLogLine(
+    context: Pick<WorkerPresentationContext, 'windowId' | 'extensionVersion'>
+): string {
+    return `[forge.temporal.worker] Forge updated the workflow worker for this window. windowId=${context.windowId} extensionVersion=${context.extensionVersion}`;
 }
 
 export function formatWorkerStateTransitionLogLine(

--- a/src/temporal/temporalPresentation.ts
+++ b/src/temporal/temporalPresentation.ts
@@ -4,6 +4,8 @@ import type {
     ExternalTemporalHealthState,
     ManagedLocalHealthState,
     StartFailureRemediation,
+    WorkerHealthState,
+    WorkerStartFailureRemediation,
 } from './types';
 
 export interface ManagedLocalPresentationContext {
@@ -24,7 +26,18 @@ export function formatPersistencePathForDisplay(
     return path.basename(persistencePath);
 }
 
-export function formatManagedLocalStatusBarLabel(state: ManagedLocalHealthState): string {
+export function formatManagedLocalStatusBarLabel(
+    state: ManagedLocalHealthState,
+    workerState?: WorkerHealthState
+): string {
+    const temporalLabel = formatTemporalConnectionSegment(state);
+    if (workerState === undefined) {
+        return temporalLabel;
+    }
+    return `${temporalLabel} · ${formatWorkerStatusBarSegment(workerState)}`;
+}
+
+function formatTemporalConnectionSegment(state: ManagedLocalHealthState): string {
     switch (state) {
         case 'idle':
             return '$(pulse) Temporal: idle';
@@ -38,6 +51,53 @@ export function formatManagedLocalStatusBarLabel(state: ManagedLocalHealthState)
             return '$(pulse) Temporal: failed';
         case 'stopped':
             return '$(pulse) Temporal: stopped';
+    }
+}
+
+export function formatWorkerStatusBarSegment(state: WorkerHealthState): string {
+    switch (state) {
+        case 'idle':
+            return 'Worker: idle';
+        case 'starting':
+            return 'Worker: starting…';
+        case 'ready':
+            return 'Worker: ready';
+        case 'unhealthy':
+            return 'Worker: unhealthy';
+        case 'start_failed':
+            return 'Worker: failed';
+        case 'restarting':
+            return 'Worker: restarting…';
+        case 'stopped':
+            return 'Worker: stopped';
+    }
+}
+
+export function formatExternalStatusBarLabel(
+    state: ExternalTemporalHealthState,
+    workerState?: WorkerHealthState
+): string {
+    const temporalLabel = formatExternalConnectionSegment(state);
+    if (workerState === undefined) {
+        return temporalLabel;
+    }
+    return `${temporalLabel} · ${formatWorkerStatusBarSegment(workerState)}`;
+}
+
+function formatExternalConnectionSegment(state: ExternalTemporalHealthState): string {
+    switch (state) {
+        case 'idle':
+            return '$(pulse) Temporal: idle';
+        case 'connecting':
+            return '$(pulse) Temporal: connecting…';
+        case 'ready':
+            return '$(pulse) Temporal: ready';
+        case 'unhealthy':
+            return '$(pulse) Temporal: unhealthy';
+        case 'connect_failed':
+            return '$(pulse) Temporal: failed';
+        case 'disconnected':
+            return '$(pulse) Temporal: disconnected';
     }
 }
 
@@ -94,23 +154,6 @@ export interface ExternalPresentationContext {
     probeErrorCode?: string;
 }
 
-export function formatExternalStatusBarLabel(state: ExternalTemporalHealthState): string {
-    switch (state) {
-        case 'idle':
-            return '$(pulse) Temporal: idle';
-        case 'connecting':
-            return '$(pulse) Temporal: connecting…';
-        case 'ready':
-            return '$(pulse) Temporal: ready';
-        case 'unhealthy':
-            return '$(pulse) Temporal: unhealthy';
-        case 'connect_failed':
-            return '$(pulse) Temporal: failed';
-        case 'disconnected':
-            return '$(pulse) Temporal: disconnected';
-    }
-}
-
 export function formatExternalStatusBarTooltip(context: {
     address: string;
     namespace: string;
@@ -156,4 +199,47 @@ export function formatExternalStateTransitionLogLine(
     const probeErrorPart =
         context.probeErrorCode !== undefined ? ` probeErrorCode=${context.probeErrorCode}` : '';
     return `[forge.temporal.external] state=${state} windowId=${context.windowId} address=${context.address} namespace=${context.namespace} authMode=${context.authMode} tlsEnabled=${context.tlsEnabled}${probeErrorPart}`;
+}
+
+export interface WorkerPresentationContext {
+    windowId: string;
+    taskQueue: string;
+    namespace: string;
+    mode: string;
+    extensionVersion: string;
+    pid?: number;
+    exitCode?: number;
+}
+
+export function formatWorkerStartFailedNotification(
+    remediation: WorkerStartFailureRemediation
+): string {
+    switch (remediation) {
+        case 'asset':
+            return 'Forge could not start the workflow worker — worker assets are missing from the extension package. Reinstall Forge Studio.';
+        case 'permission':
+            return 'Forge could not start the workflow worker — cannot write worker state. Check extension global storage permissions.';
+        case 'port':
+            return 'Forge could not start the workflow worker — Temporal connection settings are unavailable.';
+        case 'crash':
+            return 'Forge workflow worker stopped unexpectedly. See Forge Temporal output. Workflow runs are blocked until the worker is healthy.';
+    }
+}
+
+export function formatWorkerBlockedNotification(): string {
+    return 'Workflow runs are blocked until the Forge worker is ready. See Forge Temporal output for details.';
+}
+
+export function formatWorkerUpgradeRestartLogLine(context: Pick<WorkerPresentationContext, 'windowId' | 'extensionVersion'>): string {
+    return `[forge.temporal.worker] upgradeRestart windowId=${context.windowId} extensionVersion=${context.extensionVersion}`;
+}
+
+export function formatWorkerStateTransitionLogLine(
+    state: WorkerHealthState,
+    context: WorkerPresentationContext
+): string {
+    const pidPart = context.pid !== undefined ? ` pid=${context.pid}` : '';
+    const exitCodePart =
+        context.exitCode !== undefined ? ` exitCode=${context.exitCode}` : '';
+    return `[forge.temporal.worker] state=${state} windowId=${context.windowId} taskQueue=${context.taskQueue} namespace=${context.namespace} mode=${context.mode} extensionVersion=${context.extensionVersion}${pidPart}${exitCodePart}`;
 }

--- a/src/temporal/temporalReadinessGate.test.ts
+++ b/src/temporal/temporalReadinessGate.test.ts
@@ -37,6 +37,7 @@ describe('temporalReadinessGate', () => {
     it('runs external preflight when configuration is valid', async () => {
         const supervisor = {
             ensureReady: vi.fn(async () => undefined),
+            getHealthState: vi.fn(() => 'ready' as const),
         } as unknown as ExternalTemporalSupervisor;
         const readyWorkerSupervisor = createReadyWorkerSupervisor();
 

--- a/src/temporal/temporalReadinessGate.test.ts
+++ b/src/temporal/temporalReadinessGate.test.ts
@@ -3,10 +3,17 @@ import * as vscode from 'vscode';
 import { ExternalReadinessBlockedError, ExternalTemporalSupervisor } from './ExternalTemporalSupervisor';
 import { TemporalReadinessBlockedError } from './TemporalLocalSupervisor';
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
+import { TemporalWorkerSupervisor, WorkerReadinessBlockedError } from './TemporalWorkerSupervisor';
 import {
     TemporalConfigurationInvalidError,
     gateTemporalReadiness,
 } from './temporalReadinessGate';
+
+function createReadyWorkerSupervisor(): TemporalWorkerSupervisor {
+    return {
+        ensureReady: vi.fn(async () => undefined),
+    } as unknown as TemporalWorkerSupervisor;
+}
 
 describe('temporalReadinessGate', () => {
     it('validates external configuration before running external preflight', async () => {
@@ -31,11 +38,13 @@ describe('temporalReadinessGate', () => {
         const supervisor = {
             ensureReady: vi.fn(async () => undefined),
         } as unknown as ExternalTemporalSupervisor;
+        const readyWorkerSupervisor = createReadyWorkerSupervisor();
 
         await expect(
             gateTemporalReadiness({
                 resolveMode: () => 'external',
                 getExternalSupervisor: () => supervisor,
+                getWorkerSupervisor: () => readyWorkerSupervisor,
                 resolveSettings: () => ({
                     address: 'localhost:7233',
                     namespace: 'forge-external',
@@ -48,6 +57,7 @@ describe('temporalReadinessGate', () => {
         ).resolves.toBeUndefined();
 
         expect(supervisor.ensureReady).toHaveBeenCalledOnce();
+        expect(readyWorkerSupervisor.ensureReady).toHaveBeenCalledOnce();
     });
 
     it('blocks workflow run start when external preflight fails', async () => {
@@ -138,14 +148,42 @@ describe('temporalReadinessGate', () => {
         const supervisor = {
             ensureReady: vi.fn(async () => undefined),
         } as unknown as TemporalLocalSupervisor;
+        const readyWorkerSupervisor = createReadyWorkerSupervisor();
 
         await expect(
             gateTemporalReadiness({
                 resolveMode: () => 'managedLocal',
                 getSupervisor: () => supervisor,
+                getWorkerSupervisor: () => readyWorkerSupervisor,
             })
         ).resolves.toBeUndefined();
 
         expect(supervisor.ensureReady).toHaveBeenCalledOnce();
+        expect(readyWorkerSupervisor.ensureReady).toHaveBeenCalledOnce();
+    });
+
+    it('blocks workflow run start when worker supervisor is start_failed', async () => {
+        const supervisor = {
+            ensureReady: vi.fn(async () => undefined),
+        } as unknown as TemporalLocalSupervisor;
+        const workerSupervisor = {
+            ensureReady: vi.fn(async () => {
+                throw new WorkerReadinessBlockedError(
+                    {
+                        remediation: 'crash',
+                        message: 'Forge workflow worker stopped unexpectedly.',
+                    },
+                    'start_failed'
+                );
+            }),
+        } as unknown as TemporalWorkerSupervisor;
+
+        await expect(
+            gateTemporalReadiness({
+                resolveMode: () => 'managedLocal',
+                getSupervisor: () => supervisor,
+                getWorkerSupervisor: () => workerSupervisor,
+            })
+        ).rejects.toBeInstanceOf(TemporalConfigurationInvalidError);
     });
 });

--- a/src/temporal/temporalReadinessGate.ts
+++ b/src/temporal/temporalReadinessGate.ts
@@ -20,6 +20,9 @@ import { resolveTemporalMode } from './temporalSettings';
 
 export const TEMPORAL_READINESS_VALIDATOR_ID = 'forge.temporal.readiness';
 
+const EXTERNAL_POLLING_READY_TIMEOUT_MS = 10_000;
+const EXTERNAL_POLLING_READY_INTERVAL_MS = 200;
+
 export class TemporalConfigurationInvalidError extends Error {
     readonly diagnostics: Diagnostic[];
 
@@ -143,6 +146,43 @@ async function gateWorkerReadiness(
     }
 }
 
+async function awaitExternalWorkerPollingReady(
+    supervisor: ExternalTemporalSupervisor
+): Promise<void> {
+    if (supervisor.getHealthState() === 'ready') {
+        return;
+    }
+
+    const deadline = Date.now() + EXTERNAL_POLLING_READY_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        const state = supervisor.getHealthState();
+        if (state === 'ready') {
+            return;
+        }
+        if (state === 'connect_failed') {
+            const connectError = supervisor.getConnectError();
+            throw new TemporalConfigurationInvalidError([
+                externalConnectInvalidDiagnostic(
+                    connectError?.message ?? 'External Temporal connection failed.',
+                    connectError?.remediation ?? 'config'
+                ),
+            ]);
+        }
+        await delay(EXTERNAL_POLLING_READY_INTERVAL_MS);
+    }
+
+    throw new TemporalConfigurationInvalidError([
+        {
+            code: 'forge.temporal.configuration_invalid',
+            severity: 'error',
+            path: 'forge.temporal.external',
+            message:
+                'External Temporal task queue has no polling worker. Start the Forge worker and retry.',
+            validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
+        },
+    ]);
+}
+
 export async function gateTemporalReadiness(
     options: TemporalReadinessGateOptions = {}
 ): Promise<void> {
@@ -184,6 +224,7 @@ export async function gateTemporalReadiness(
         }
 
         await gateWorkerReadiness(options);
+        await awaitExternalWorkerPollingReady(supervisor);
         return;
     }
 
@@ -216,4 +257,10 @@ export async function gateTemporalReadiness(
     }
 
     await gateWorkerReadiness(options);
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
 }

--- a/src/temporal/temporalReadinessGate.ts
+++ b/src/temporal/temporalReadinessGate.ts
@@ -1,10 +1,15 @@
 import type { Diagnostic } from '../workflows/types';
 import { ExternalReadinessBlockedError, ExternalTemporalSupervisor } from './ExternalTemporalSupervisor';
 import { TemporalLocalSupervisor, TemporalReadinessBlockedError } from './TemporalLocalSupervisor';
-import { notifyWorkflowBlockedByTemporal } from './temporalHealthSurfaces';
+import { TemporalWorkerSupervisor, WorkerReadinessBlockedError } from './TemporalWorkerSupervisor';
+import {
+    notifyWorkflowBlockedByTemporal,
+    notifyWorkflowBlockedByWorker,
+} from './temporalHealthSurfaces';
 import {
     getExternalTemporalSupervisor,
     getTemporalLocalSupervisor,
+    getTemporalWorkerSupervisor,
 } from './temporalWindowRegistry';
 import {
     getTemporalConfigurationErrors,
@@ -28,6 +33,7 @@ export class TemporalConfigurationInvalidError extends Error {
 export interface TemporalReadinessGateOptions extends TemporalConfigurationValidationOptions {
     getSupervisor?: () => TemporalLocalSupervisor | undefined;
     getExternalSupervisor?: () => ExternalTemporalSupervisor | undefined;
+    getWorkerSupervisor?: () => TemporalWorkerSupervisor | undefined;
     resolveMode?: () => ReturnType<typeof resolveTemporalMode>;
 }
 
@@ -57,6 +63,19 @@ function externalConnectRemediationMessage(remediation: string): string {
     }
 }
 
+function workerRemediationMessage(remediation: string): string {
+    switch (remediation) {
+        case 'asset':
+            return 'Reinstall Forge Studio or verify worker assets in the extension package.';
+        case 'permission':
+            return 'Check extension global storage permissions.';
+        case 'crash':
+            return 'See Forge Temporal output and restart the window.';
+        default:
+            return 'See Forge Temporal output for worker startup details.';
+    }
+}
+
 function externalConnectInvalidDiagnostic(
     message: string,
     remediation: string
@@ -69,6 +88,7 @@ function externalConnectInvalidDiagnostic(
         validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
     };
 }
+
 function configurationInvalidDiagnostic(
     message: string,
     remediation: string
@@ -80,6 +100,47 @@ function configurationInvalidDiagnostic(
         message: `${message} ${remediationMessage(remediation)}`,
         validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
     };
+}
+
+function workerInvalidDiagnostic(message: string, remediation: string): Diagnostic {
+    return {
+        code: 'forge.temporal.configuration_invalid',
+        severity: 'error',
+        path: 'forge.temporal.worker',
+        message: `${message} ${workerRemediationMessage(remediation)}`,
+        validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
+    };
+}
+
+async function gateWorkerReadiness(
+    options: TemporalReadinessGateOptions
+): Promise<void> {
+    const workerSupervisor =
+        options.getWorkerSupervisor?.() ?? getTemporalWorkerSupervisor();
+    if (!workerSupervisor) {
+        throw new TemporalConfigurationInvalidError([
+            {
+                code: 'forge.temporal.configuration_invalid',
+                severity: 'error',
+                path: 'forge.temporal.worker',
+                message:
+                    'Forge workflow worker supervisor is not registered for this window. Reload the window and retry.',
+                validator_id: TEMPORAL_READINESS_VALIDATOR_ID,
+            },
+        ]);
+    }
+
+    try {
+        await workerSupervisor.ensureReady();
+    } catch (error) {
+        if (error instanceof WorkerReadinessBlockedError) {
+            notifyWorkflowBlockedByWorker();
+            throw new TemporalConfigurationInvalidError([
+                workerInvalidDiagnostic(error.message, error.remediation),
+            ]);
+        }
+        throw error;
+    }
 }
 
 export async function gateTemporalReadiness(
@@ -121,6 +182,8 @@ export async function gateTemporalReadiness(
             }
             throw error;
         }
+
+        await gateWorkerReadiness(options);
         return;
     }
 
@@ -151,4 +214,6 @@ export async function gateTemporalReadiness(
         }
         throw error;
     }
+
+    await gateWorkerReadiness(options);
 }

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -3,6 +3,7 @@ import {
     ExternalTemporalSupervisor,
 } from './ExternalTemporalSupervisor';
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
+import { TemporalWorkerSupervisor } from './TemporalWorkerSupervisor';
 import { getRegisteredStoredApiKeyReader } from './externalCredentials';
 import { resolveExternalApiKey, resolveExternalSettings } from './externalSettings';
 import {
@@ -14,12 +15,18 @@ import {
     createTemporalOutputChannel,
     registerExternalTemporalHealthSurfaces,
     registerManagedLocalTemporalHealthSurfaces,
+    registerWorkerHealthSurfaces,
 } from './temporalHealthSurfaces';
 import { formatPersistencePathForDisplay } from './temporalPresentation';
-import type { ExternalTemporalSupervisorConfig, ManagedLocalSupervisorConfig } from './types';
+import type {
+    ExternalTemporalSupervisorConfig,
+    ManagedLocalSupervisorConfig,
+    TemporalWorkerSupervisorConfig,
+} from './types';
 
 let localSupervisor: TemporalLocalSupervisor | undefined;
 let externalSupervisor: ExternalTemporalSupervisor | undefined;
+let workerSupervisor: TemporalWorkerSupervisor | undefined;
 
 export function getTemporalLocalSupervisor(): TemporalLocalSupervisor | undefined {
     return localSupervisor;
@@ -27,6 +34,63 @@ export function getTemporalLocalSupervisor(): TemporalLocalSupervisor | undefine
 
 export function getExternalTemporalSupervisor(): ExternalTemporalSupervisor | undefined {
     return externalSupervisor;
+}
+
+export function getTemporalWorkerSupervisor(): TemporalWorkerSupervisor | undefined {
+    return workerSupervisor;
+}
+
+function isTemporalConnectionReady(): boolean {
+    if (resolveTemporalMode() === 'external') {
+        return externalSupervisor?.getHealthState() === 'ready';
+    }
+    return localSupervisor?.getHealthState() === 'ready';
+}
+
+function registerWorkerSupervisor(
+    context: vscode.ExtensionContext,
+    outputChannel: vscode.OutputChannel,
+    input: {
+        windowId: string;
+        namespace: string;
+        taskQueue: string;
+        grpcPort?: number;
+    }
+): TemporalWorkerSupervisor {
+    const mode = resolveTemporalMode();
+    const workerConfig: TemporalWorkerSupervisorConfig = {
+        windowId: input.windowId,
+        extensionPath: context.extensionPath,
+        extensionVersion: context.extension.packageJSON.version,
+        globalStoragePath: context.globalStorageUri.fsPath,
+        mode,
+        namespace: input.namespace,
+        taskQueue: input.taskQueue,
+        grpcPort: input.grpcPort,
+        resolveExternalSettings: mode === 'external' ? resolveExternalSettings : undefined,
+        resolveApiKey:
+            mode === 'external'
+                ? () => resolveExternalApiKey(getRegisteredStoredApiKeyReader())
+                : undefined,
+        isTemporalConnectionReady,
+    };
+
+    workerSupervisor = new TemporalWorkerSupervisor(workerConfig, {
+        log: (line) => {
+            outputChannel.appendLine(line);
+        },
+    });
+
+    registerWorkerHealthSurfaces(context, workerSupervisor, workerConfig, outputChannel);
+
+    context.subscriptions.push({
+        dispose: () => {
+            void workerSupervisor?.stop();
+            workerSupervisor = undefined;
+        },
+    });
+
+    return workerSupervisor;
 }
 
 export function registerTemporalLocalSupervisor(
@@ -57,6 +121,13 @@ export function registerTemporalLocalSupervisor(
             resolveExternalSettings,
             outputChannel
         );
+
+        const externalSettings = resolveExternalSettings();
+        registerWorkerSupervisor(context, outputChannel, {
+            windowId,
+            namespace: externalSettings.namespace ?? 'unknown',
+            taskQueue: externalSettings.taskQueue,
+        });
 
         context.subscriptions.push({
             dispose: () => {
@@ -105,6 +176,13 @@ export function registerTemporalLocalSupervisor(
         outputChannel
     );
 
+    registerWorkerSupervisor(context, outputChannel, {
+        windowId,
+        namespace: settings.namespace,
+        taskQueue: settings.taskQueue,
+        grpcPort: settings.grpcPort,
+    });
+
     context.subscriptions.push({
         dispose: () => {
             void localSupervisor?.stop();
@@ -116,6 +194,8 @@ export function registerTemporalLocalSupervisor(
 }
 
 export async function shutdownTemporalLocalSupervisor(): Promise<void> {
+    await workerSupervisor?.stop();
+    workerSupervisor = undefined;
     await localSupervisor?.stop();
     localSupervisor = undefined;
     await externalSupervisor?.stop();

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -42,7 +42,8 @@ export function getTemporalWorkerSupervisor(): TemporalWorkerSupervisor | undefi
 
 function isTemporalConnectionReady(): boolean {
     if (resolveTemporalMode() === 'external') {
-        return externalSupervisor?.getHealthState() === 'ready';
+        const state = externalSupervisor?.getHealthState();
+        return state === 'ready' || state === 'unhealthy';
     }
     return localSupervisor?.getHealthState() === 'ready';
 }

--- a/src/temporal/types.ts
+++ b/src/temporal/types.ts
@@ -6,6 +6,15 @@ export type ManagedLocalHealthState =
     | 'start_failed'
     | 'stopped';
 
+export type WorkerHealthState =
+    | 'idle'
+    | 'starting'
+    | 'ready'
+    | 'unhealthy'
+    | 'start_failed'
+    | 'restarting'
+    | 'stopped';
+
 export type ExternalTemporalHealthState =
     | 'idle'
     | 'connecting'
@@ -46,6 +55,28 @@ export interface ManagedLocalStartError {
     remediation: StartFailureRemediation;
     message: string;
     exitCode?: number;
+}
+
+export type WorkerStartFailureRemediation = StartFailureRemediation | 'crash';
+
+export interface WorkerStartError {
+    remediation: WorkerStartFailureRemediation;
+    message: string;
+    exitCode?: number;
+}
+
+export interface TemporalWorkerSupervisorConfig {
+    windowId: string;
+    extensionPath: string;
+    extensionVersion: string;
+    globalStoragePath: string;
+    mode: import('./temporalSettings').TemporalMode;
+    namespace: string;
+    taskQueue: string;
+    grpcPort?: number;
+    resolveExternalSettings?: () => import('./externalSettings').ResolvedExternalSettings;
+    resolveApiKey?: () => Promise<string | undefined>;
+    isTemporalConnectionReady: () => boolean;
 }
 
 export interface SpawnedChildProcess {

--- a/src/temporal/workerFailureClassification.ts
+++ b/src/temporal/workerFailureClassification.ts
@@ -1,0 +1,30 @@
+import { classifyStartFailure } from './failureClassification';
+import type { StartFailureRemediation } from './types';
+
+export interface ClassifiedWorkerStartFailure {
+    remediation: StartFailureRemediation | 'crash';
+    message: string;
+}
+
+export function classifyWorkerStartFailure(input: {
+    spawnError?: Error;
+    exitCode?: number | null;
+    stderr?: string;
+    repeatedCrash?: boolean;
+}): ClassifiedWorkerStartFailure {
+    if (input.repeatedCrash) {
+        return {
+            remediation: 'crash',
+            message: 'Forge workflow worker stopped unexpectedly after repeated supervised restarts.',
+        };
+    }
+
+    const classified = classifyStartFailure(input);
+    return {
+        remediation: classified.remediation,
+        message: classified.message.replace(
+            /managed-local Temporal dev server/gi,
+            'Forge workflow worker'
+        ),
+    };
+}

--- a/src/temporal/workerLaunch.test.ts
+++ b/src/temporal/workerLaunch.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildWorkerSpawnEnv,
+    resolveExternalWorkerConnection,
+    resolveManagedLocalWorkerConnection,
+} from './workerLaunch';
+import type { TemporalWorkerSupervisorConfig } from './types';
+
+const baseConfig: TemporalWorkerSupervisorConfig = {
+    windowId: 'window-test',
+    extensionPath: '/extension',
+    extensionVersion: '3.26.3',
+    globalStoragePath: '/storage',
+    mode: 'managedLocal',
+    namespace: 'forge-local',
+    taskQueue: 'forge-workflows',
+    grpcPort: 7233,
+    isTemporalConnectionReady: () => true,
+};
+
+describe('buildWorkerSpawnEnv', () => {
+    it('injects managed-local Temporal settings into worker env', () => {
+        const connection = resolveManagedLocalWorkerConnection({
+            grpcPort: 7233,
+            namespace: 'forge-local',
+            taskQueue: 'forge-workflows',
+        });
+
+        const env = buildWorkerSpawnEnv(baseConfig, connection);
+
+        expect(env.FORGE_TEMPORAL_MODE).toBe('managedLocal');
+        expect(env.FORGE_TEMPORAL_WINDOW_ID).toBe('window-test');
+        expect(env.FORGE_TEMPORAL_ADDRESS).toBe('127.0.0.1:7233');
+        expect(env.FORGE_TEMPORAL_MANAGED_LOCAL_NAMESPACE).toBe('forge-local');
+        expect(env.FORGE_TEMPORAL_MANAGED_LOCAL_TASK_QUEUE).toBe('forge-workflows');
+        expect(env.FORGE_TEMPORAL_MANAGED_LOCAL_GRPC_PORT).toBe('7233');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_API_KEY).toBeUndefined();
+    });
+
+    it('injects external Temporal settings and API key at spawn only', () => {
+        const externalSettings = {
+            address: 'temporal.example.com:7233',
+            namespace: 'forge-external',
+            taskQueue: 'forge-workflows',
+            authMode: 'apiKey' as const,
+            tlsEnabled: true,
+            tlsServerName: 'temporal.example.com',
+        };
+        const connection = resolveExternalWorkerConnection(
+            externalSettings,
+            'super-secret-api-key'
+        );
+
+        const env = buildWorkerSpawnEnv(
+            { ...baseConfig, mode: 'external' },
+            connection
+        );
+
+        expect(env.FORGE_TEMPORAL_MODE).toBe('external');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_ADDRESS).toBe('temporal.example.com:7233');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_NAMESPACE).toBe('forge-external');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_TASK_QUEUE).toBe('forge-workflows');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_AUTH_MODE).toBe('apiKey');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_TLS_ENABLED).toBe('true');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_TLS_SERVER_NAME).toBe('temporal.example.com');
+        expect(env.FORGE_TEMPORAL_EXTERNAL_API_KEY).toBe('super-secret-api-key');
+        expect(env.FORGE_TEMPORAL_MANAGED_LOCAL_NAMESPACE).toBeUndefined();
+    });
+
+    it('omits external API key from env when credential is unavailable', () => {
+        const externalSettings = {
+            address: 'temporal.example.com:7233',
+            namespace: 'forge-external',
+            taskQueue: 'forge-workflows',
+            authMode: 'tlsServer' as const,
+            tlsEnabled: true,
+            tlsServerName: '',
+        };
+        const connection = resolveExternalWorkerConnection(externalSettings, undefined);
+
+        const env = buildWorkerSpawnEnv(
+            { ...baseConfig, mode: 'external' },
+            connection
+        );
+
+        expect(env.FORGE_TEMPORAL_EXTERNAL_API_KEY).toBeUndefined();
+    });
+});

--- a/src/temporal/workerLaunch.ts
+++ b/src/temporal/workerLaunch.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import path from 'path';
+import { buildExternalConnectionOptions } from './externalConnection';
+import type { ResolvedExternalSettings } from './externalSettings';
+import { buildManagedLocalGrpcAddress } from './devServerLaunch';
+import type { TemporalMode } from './temporalSettings';
+import type { TemporalWorkerSupervisorConfig } from './types';
+
+export const WORKER_ENTRY = path.join('resources', 'workflow', 'worker', 'start-worker.js');
+
+export function resolveWorkerEntry(extensionPath: string): string {
+    return path.join(extensionPath, WORKER_ENTRY);
+}
+
+export function assertWorkerEntryExists(extensionPath: string): void {
+    const entryPath = resolveWorkerEntry(extensionPath);
+    if (!fs.existsSync(entryPath)) {
+        throw new Error(`Temporal worker entry not found at ${entryPath}`);
+    }
+}
+
+export function resolveWorkerManifestPath(
+    globalStoragePath: string,
+    windowId: string
+): string {
+    return path.join(globalStoragePath, 'temporal', windowId, 'worker-manifest.json');
+}
+
+export function buildWorkerSpawnEnv(
+    config: TemporalWorkerSupervisorConfig,
+    connection: {
+        mode: TemporalMode;
+        address: string;
+        namespace: string;
+        taskQueue: string;
+        externalSettings?: ResolvedExternalSettings;
+        apiKey?: string;
+    }
+): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        FORGE_TEMPORAL_MODE: connection.mode,
+        FORGE_TEMPORAL_WINDOW_ID: config.windowId,
+        FORGE_TEMPORAL_ADDRESS: connection.address,
+    };
+
+    if (connection.mode === 'managedLocal') {
+        env.FORGE_TEMPORAL_MANAGED_LOCAL_NAMESPACE = connection.namespace;
+        env.FORGE_TEMPORAL_MANAGED_LOCAL_TASK_QUEUE = connection.taskQueue;
+        const grpcPort = connection.address.split(':').pop();
+        if (grpcPort) {
+            env.FORGE_TEMPORAL_MANAGED_LOCAL_GRPC_PORT = grpcPort;
+        }
+    } else if (connection.externalSettings) {
+        env.FORGE_TEMPORAL_EXTERNAL_ADDRESS = connection.externalSettings.address ?? '';
+        env.FORGE_TEMPORAL_EXTERNAL_NAMESPACE = connection.namespace;
+        env.FORGE_TEMPORAL_EXTERNAL_TASK_QUEUE = connection.taskQueue;
+        env.FORGE_TEMPORAL_EXTERNAL_AUTH_MODE = connection.externalSettings.authMode;
+        env.FORGE_TEMPORAL_EXTERNAL_TLS_ENABLED = String(connection.externalSettings.tlsEnabled);
+        if (connection.externalSettings.tlsServerName) {
+            env.FORGE_TEMPORAL_EXTERNAL_TLS_SERVER_NAME =
+                connection.externalSettings.tlsServerName;
+        }
+        if (connection.apiKey) {
+            env.FORGE_TEMPORAL_EXTERNAL_API_KEY = connection.apiKey;
+        }
+    }
+
+    return env;
+}
+
+export function resolveManagedLocalWorkerConnection(input: {
+    grpcPort: number;
+    namespace: string;
+    taskQueue: string;
+}): {
+    mode: TemporalMode;
+    address: string;
+    namespace: string;
+    taskQueue: string;
+} {
+    return {
+        mode: 'managedLocal',
+        address: buildManagedLocalGrpcAddress(input.grpcPort),
+        namespace: input.namespace,
+        taskQueue: input.taskQueue,
+    };
+}
+
+export function resolveExternalWorkerConnection(
+    settings: ResolvedExternalSettings,
+    apiKey: string | undefined
+): {
+    mode: TemporalMode;
+    address: string;
+    namespace: string;
+    taskQueue: string;
+    externalSettings: ResolvedExternalSettings;
+    apiKey: string | undefined;
+    connectionOptions: ReturnType<typeof buildExternalConnectionOptions>;
+} {
+    return {
+        mode: 'external',
+        address: settings.address ?? '',
+        namespace: settings.namespace ?? '',
+        taskQueue: settings.taskQueue,
+        externalSettings: settings,
+        apiKey,
+        connectionOptions: buildExternalConnectionOptions(settings, apiKey),
+    };
+}

--- a/src/temporal/workerManifest.ts
+++ b/src/temporal/workerManifest.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface WorkerManifest {
+    extensionVersion: string;
+    workerEntryPath: string;
+    pid: number;
+}
+
+export function readWorkerManifest(manifestPath: string): WorkerManifest | undefined {
+    if (!fs.existsSync(manifestPath)) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as WorkerManifest;
+        if (
+            typeof parsed.extensionVersion !== 'string' ||
+            typeof parsed.workerEntryPath !== 'string' ||
+            typeof parsed.pid !== 'number'
+        ) {
+            return undefined;
+        }
+        return parsed;
+    } catch {
+        return undefined;
+    }
+}
+
+export function writeWorkerManifest(manifestPath: string, manifest: WorkerManifest): void {
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+export function workerManifestVersionMismatch(
+    manifest: WorkerManifest | undefined,
+    extensionVersion: string
+): boolean {
+    return manifest !== undefined && manifest.extensionVersion !== extensionVersion;
+}

--- a/src/workflows/validateWorkflowForRun.test.ts
+++ b/src/workflows/validateWorkflowForRun.test.ts
@@ -184,16 +184,20 @@ describe('gateWorkflowRunStart', () => {
     it('combines definition validation with managed-local temporal readiness', async () => {
         const ensureReady = vi.fn(async () => undefined);
         const supervisor = { ensureReady };
+        const workerEnsureReady = vi.fn(async () => undefined);
+        const workerSupervisor = { ensureReady: workerEnsureReady };
 
         const result = await gateWorkflowRunStartWithTemporalReadiness({
             workspaceRoots: [process.cwd()],
             workflowId: 'refine-issue',
             resolveMode: () => 'managedLocal',
             getSupervisor: () => supervisor as never,
+            getWorkerSupervisor: () => workerSupervisor as never,
         });
 
         expect(result.valid).toBe(true);
         expect(ensureReady).toHaveBeenCalledOnce();
+        expect(workerEnsureReady).toHaveBeenCalledOnce();
     });
 
     it('blocks combined gate when temporal readiness fails after validation passes', async () => {


### PR DESCRIPTION
## Summary

- Add packaged worker launch entry at `resources/workflow/worker/start-worker.js` and window-scoped `TemporalWorkerSupervisor` with crash restart (exponential backoff, 30s cap), graceful stop, and `worker-manifest.json` upgrade detection.
- Pass resolved mode-aware `FORGE_TEMPORAL_*` settings into the worker child at spawn; inject external API keys from SecretStorage at spawn only (never logged or persisted in manifest).
- Gate workflow readiness on Temporal connection health **and** supervised worker task-queue poll readiness; external mode reports `unhealthy` until a worker polls, then transitions to `ready`.
- Surface worker health through the same v1 Forge Temporal Output channel, status bar compound segments, and notifications as Temporal connection health (#42).
- Add `scripts/verify-packaging.sh` and CI step to assert dev server and worker launch assets resolve from a clean package build.

## Linked issues

- Implements #40 (sub-issue of #20)
- Implements #41 (sub-issue of #20)
- Implements #42 (sub-issue of #20)
- Part of #20 (Temporal workers outside extension host)

Closes #40
Closes #41
Closes #42

## Test plan

- [x] `npm run lint`
- [x] `npm test` (262 tests)
- [x] `bash scripts/verify-packaging.sh`
- [ ] F5 extension: trigger readiness gate; confirm one worker child per window with correct env vars
- [ ] External mode: confirm worker connects with injected credentials; no secrets in Output logs
- [ ] Stop worker process; confirm workflow run creation blocked with remediation copy
- [ ] Kill worker process; confirm supervised restart to `restarting` then `ready` or `start_failed`
- [ ] Install newer extension build; confirm worker restarts on next readiness from manifest version mismatch
- [ ] Observe Output channel during worker `starting` → `ready`; confirm compound status bar and first-ready notification (#42)
- [ ] Simulate worker `start_failed`; confirm error notification and worker-specific blocked-run copy (#42)