### PR TITLE
feat(temporal): workflow run recovery (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,64 @@
       {
         "command": "forge.clearTemporalApiKey",
         "title": "Forge: Clear Temporal API Key"
+      },
+      {
+        "command": "forge.refreshWorkflowRuns",
+        "title": "Forge: Refresh workflow runs"
+      },
+      {
+        "command": "forge.openWorkflowRunList",
+        "title": "Forge: Open Workflow Run List"
+      },
+      {
+        "command": "forge.cancelWorkflowRun",
+        "title": "Forge: Cancel Workflow Run"
+      },
+      {
+        "command": "forge.dismissOrphanedWorkflowRun",
+        "title": "Forge: Dismiss Orphaned Workflow Run"
+      },
+      {
+        "command": "forge.openQuestionPanel",
+        "title": "Forge: Open Question Panel"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "forge",
+          "title": "Forge",
+          "icon": "resources/icons/forge-logo.png"
+        }
+      ]
+    },
+    "views": {
+      "forge": [
+        {
+          "id": "forge.workflowRunList",
+          "name": "Workflow Runs"
+        }
+      ]
+    },
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "forge.cancelWorkflowRun",
+          "when": "view == forge.workflowRunList && viewItem == syncedActive",
+          "group": "runActions@1"
+        },
+        {
+          "command": "forge.openQuestionPanel",
+          "when": "view == forge.workflowRunList && viewItem == needsInput",
+          "group": "runActions@2"
+        },
+        {
+          "command": "forge.dismissOrphanedWorkflowRun",
+          "when": "view == forge.workflowRunList && viewItem == orphaned",
+          "group": "runActions@3"
+        }
+      ]
+    },
     "configuration": {
       "title": "Forge",
       "properties": {

--- a/src/commands/WorkflowRunRecoveryCommands.ts
+++ b/src/commands/WorkflowRunRecoveryCommands.ts
@@ -1,0 +1,217 @@
+import * as vscode from 'vscode';
+import {
+    formatCancelConfirmMessage,
+    formatHumanInputBlockedMessage,
+    formatRunActionsBlockedMessage,
+} from '../temporal/temporalPresentation';
+import {
+    cancelWorkflowRun,
+    dismissOrphanedWorkflowRun,
+    evaluateHumanInputSubmit,
+    evaluateWorkflowRunAction,
+    readProjectionForEntry,
+} from '../temporal/workflowRunActions';
+import {
+    getWorkflowRunRecoveryContext,
+    notifyWorkflowRunIndexChanged,
+    refreshWorkflowRunsManually,
+} from '../temporal/workflowRunRecoveryService';
+import {
+    registerWorkflowRunListProvider,
+    WORKFLOW_RUN_LIST_VIEW_ID,
+    type WorkflowRunTreeItem,
+} from '../temporal/WorkflowRunListProvider';
+import type { WorkflowRunIndexEntry } from '../temporal/workflowRunIndex';
+
+function resolveSelectedEntry(
+    item?: WorkflowRunTreeItem
+): { entry: WorkflowRunIndexEntry; indexKey: string } | undefined {
+    const context = getWorkflowRunRecoveryContext();
+    if (!context) {
+        return undefined;
+    }
+
+    if (item?.entry) {
+        return { entry: item.entry, indexKey: item.indexKey };
+    }
+
+    const entries = context.indexStore.listEntries();
+    if (entries.length !== 1) {
+        return undefined;
+    }
+
+    const entry = entries[0];
+    return {
+        entry,
+        indexKey: `${entry.namespace}:${entry.workflowId}:${entry.runId}`,
+    };
+}
+
+async function pickRunEntry(): Promise<
+    { entry: WorkflowRunIndexEntry; indexKey: string } | undefined
+> {
+    const context = getWorkflowRunRecoveryContext();
+    if (!context) {
+        void vscode.window.showErrorMessage('Workflow run recovery is not initialized.');
+        return undefined;
+    }
+
+    const entries = context.indexStore.listEntries();
+    if (entries.length === 0) {
+        void vscode.window.showInformationMessage('No workflow runs are indexed for this window.');
+        return undefined;
+    }
+
+    if (entries.length === 1) {
+        const entry = entries[0];
+        return {
+            entry,
+            indexKey: `${entry.namespace}:${entry.workflowId}:${entry.runId}`,
+        };
+    }
+
+    const picked = await vscode.window.showQuickPick(
+        entries.map((entry) => ({
+            label: `${entry.workflow_id} (${entry.workflowId}/${entry.runId})`,
+            description: entry.recoveryState,
+            entry,
+            indexKey: `${entry.namespace}:${entry.workflowId}:${entry.runId}`,
+        })),
+        { placeHolder: 'Select a workflow run' }
+    );
+
+    if (!picked) {
+        return undefined;
+    }
+
+    return { entry: picked.entry, indexKey: picked.indexKey };
+}
+
+export function registerWorkflowRunRecoveryCommands(context: vscode.ExtensionContext): void {
+    registerWorkflowRunListProvider(context);
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('forge.refreshWorkflowRuns', async () => {
+            try {
+                await refreshWorkflowRunsManually();
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                void vscode.window.showErrorMessage(message);
+            }
+        }),
+        vscode.commands.registerCommand('forge.openWorkflowRunList', async () => {
+            await vscode.commands.executeCommand(`${WORKFLOW_RUN_LIST_VIEW_ID}.focus`);
+        }),
+        vscode.commands.registerCommand(
+            'forge.cancelWorkflowRun',
+            async (item?: WorkflowRunTreeItem) => {
+                const context = getWorkflowRunRecoveryContext();
+                if (!context) {
+                    void vscode.window.showErrorMessage('Workflow run recovery is not initialized.');
+                    return;
+                }
+
+                const selected = resolveSelectedEntry(item) ?? (await pickRunEntry());
+                if (!selected) {
+                    return;
+                }
+
+                const projection = readProjectionForEntry(
+                    selected.entry,
+                    context.globalStoragePath,
+                    context.windowId
+                );
+                const guard = evaluateWorkflowRunAction(selected.entry, 'cancel', projection);
+                if (!guard.allowed) {
+                    void vscode.window.showWarningMessage(guard.reason ?? formatRunActionsBlockedMessage());
+                    return;
+                }
+
+                const confirmed = await vscode.window.showWarningMessage(
+                    formatCancelConfirmMessage(selected.entry.workflowId, selected.entry.runId),
+                    { modal: true },
+                    'Cancel run'
+                );
+                if (confirmed !== 'Cancel run') {
+                    return;
+                }
+
+                const client = await context.createRecoveryClient();
+                try {
+                    await cancelWorkflowRun(selected.entry, {
+                        indexStore: context.indexStore,
+                        globalStoragePath: context.globalStoragePath,
+                        windowId: context.windowId,
+                        client,
+                    });
+                    notifyWorkflowRunIndexChanged();
+                } finally {
+                    await client.close();
+                }
+            }
+        ),
+        vscode.commands.registerCommand(
+            'forge.dismissOrphanedWorkflowRun',
+            async (item?: WorkflowRunTreeItem) => {
+                const context = getWorkflowRunRecoveryContext();
+                if (!context) {
+                    void vscode.window.showErrorMessage('Workflow run recovery is not initialized.');
+                    return;
+                }
+
+                const selected = resolveSelectedEntry(item) ?? (await pickRunEntry());
+                if (!selected) {
+                    return;
+                }
+
+                const guard = evaluateWorkflowRunAction(selected.entry, 'dismiss');
+                if (!guard.allowed) {
+                    void vscode.window.showWarningMessage(guard.reason ?? formatRunActionsBlockedMessage());
+                    return;
+                }
+
+                dismissOrphanedWorkflowRun(selected.entry, {
+                    indexStore: context.indexStore,
+                    globalStoragePath: context.globalStoragePath,
+                    windowId: context.windowId,
+                });
+                notifyWorkflowRunIndexChanged();
+            }
+        ),
+        vscode.commands.registerCommand(
+            'forge.openQuestionPanel',
+            async (item?: WorkflowRunTreeItem) => {
+                const context = getWorkflowRunRecoveryContext();
+                if (!context) {
+                    void vscode.window.showErrorMessage('Workflow run recovery is not initialized.');
+                    return;
+                }
+
+                const selected = resolveSelectedEntry(item) ?? (await pickRunEntry());
+                if (!selected) {
+                    return;
+                }
+
+                const projection = readProjectionForEntry(
+                    selected.entry,
+                    context.globalStoragePath,
+                    context.windowId
+                );
+                const guard = evaluateHumanInputSubmit(selected.entry, projection);
+                if (!guard.allowed) {
+                    void vscode.window.showWarningMessage(
+                        guard.reason ?? formatHumanInputBlockedMessage()
+                    );
+                    return;
+                }
+
+                void vscode.commands.executeCommand('forge.openQuestionPanelForRun', selected.indexKey);
+            }
+        ),
+        vscode.commands.registerCommand('forge.openQuestionPanelForRun', async (indexKey: string) => {
+            void vscode.window.showInformationMessage(
+                `Question panel for run ${indexKey} opens when Forge question panel (#27) is available.`
+            );
+        })
+    );
+}

--- a/src/temporal/WorkflowRunListProvider.ts
+++ b/src/temporal/WorkflowRunListProvider.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import {
+    formatNeedsInputBadgeLabel,
+    formatRecoveryBadgeLabel,
+} from './temporalPresentation';
+import {
+    createRunIndexEntryKey,
+    type WorkflowRunIndexEntry,
+} from './workflowRunIndex';
+import {
+    isHumanInputRequired,
+    readProjectionForEntry,
+} from './workflowRunActions';
+import {
+    getWorkflowRunRecoveryContext,
+    onWorkflowRunIndexChanged,
+} from './workflowRunRecoveryService';
+
+export const WORKFLOW_RUN_LIST_VIEW_ID = 'forge.workflowRunList';
+
+function buildTreeItemContextValue(entry: WorkflowRunIndexEntry, needsInput: boolean): string {
+    if (needsInput && entry.recoveryState === 'synced') {
+        return 'needsInput';
+    }
+
+    switch (entry.recoveryState) {
+        case 'synced':
+            return entry.terminal ? 'syncedTerminal' : 'syncedActive';
+        case 'orphaned':
+            return 'orphaned';
+        case 'recovery_pending':
+            return 'recoveryPending';
+        case 'refresh_failed':
+            return 'refreshFailed';
+        case 'unreachable':
+            return 'unreachable';
+    }
+}
+
+export class WorkflowRunListProvider implements vscode.TreeDataProvider<WorkflowRunTreeItem> {
+    private readonly _onDidChangeTreeData = new vscode.EventEmitter<WorkflowRunTreeItem | undefined>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+    private disposeListener: (() => void) | undefined;
+
+    constructor() {
+        this.disposeListener = onWorkflowRunIndexChanged(() => {
+            this.refresh();
+        });
+    }
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire(undefined);
+    }
+
+    dispose(): void {
+        this.disposeListener?.();
+        this._onDidChangeTreeData.dispose();
+    }
+
+    getTreeItem(element: WorkflowRunTreeItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(): WorkflowRunTreeItem[] {
+        const context = getWorkflowRunRecoveryContext();
+        if (!context) {
+            return [];
+        }
+
+        return context.indexStore
+            .listEntries()
+            .sort((left, right) => right.startedAt.localeCompare(left.startedAt))
+            .map((entry) => {
+                const key = createRunIndexEntryKey(entry);
+                const projection = readProjectionForEntry(
+                    entry,
+                    context.globalStoragePath,
+                    context.windowId
+                );
+                const needsInput = isHumanInputRequired(projection);
+                const badge = formatRecoveryBadgeLabel(entry.recoveryState);
+                const descriptionParts = [badge];
+                if (needsInput && entry.recoveryState === 'synced') {
+                    descriptionParts.push(formatNeedsInputBadgeLabel());
+                }
+
+                const item = new WorkflowRunTreeItem(
+                    `${entry.workflow_id} (${entry.workflowId}/${entry.runId})`,
+                    descriptionParts.join(' · '),
+                    vscode.TreeItemCollapsibleState.None,
+                    key
+                );
+                item.contextValue = buildTreeItemContextValue(entry, needsInput);
+                item.tooltip = `${entry.repositoryRoot}\n${badge}`;
+                item.entry = entry;
+                return item;
+            });
+    }
+}
+
+export class WorkflowRunTreeItem extends vscode.TreeItem {
+    entry?: WorkflowRunIndexEntry;
+
+    constructor(
+        label: string,
+        description: string,
+        collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly indexKey: string
+    ) {
+        super(label, collapsibleState);
+        this.description = description;
+    }
+}
+
+export function registerWorkflowRunListProvider(
+    context: vscode.ExtensionContext
+): WorkflowRunListProvider {
+    const provider = new WorkflowRunListProvider();
+    const treeView = vscode.window.createTreeView(WORKFLOW_RUN_LIST_VIEW_ID, {
+        treeDataProvider: provider,
+        showCollapseAll: false,
+    });
+    context.subscriptions.push(treeView, { dispose: () => provider.dispose() });
+    return provider;
+}

--- a/src/temporal/humanAnswerSubmit.test.ts
+++ b/src/temporal/humanAnswerSubmit.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    DEFAULT_HUMAN_ANSWER_UPDATE,
+    createHumanAnswerSubmitClient,
+    submitHumanAnswer,
+} from './humanAnswerSubmit';
+import type { TemporalRecoveryClient } from './temporalRecoveryScan';
+
+describe('humanAnswerSubmit', () => {
+    it('routes answer submission through the declared Temporal workflow update', async () => {
+        const executeWorkflowUpdate = vi.fn(async () => undefined);
+        const recoveryClient: TemporalRecoveryClient = {
+            describeWorkflow: vi.fn(),
+            fetchHistory: vi.fn(),
+            terminateWorkflow: vi.fn(),
+            executeWorkflowUpdate,
+            close: vi.fn(),
+        };
+
+        const client = createHumanAnswerSubmitClient(recoveryClient);
+        const payload = {
+            question_id: 'user_verification_batch',
+            node_id: 'human-1',
+            answers: { q1: 'yes' },
+        };
+
+        await submitHumanAnswer(client, {
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            payload,
+        });
+
+        expect(executeWorkflowUpdate).toHaveBeenCalledWith(
+            'forge-local',
+            'wf-1',
+            'run-1',
+            DEFAULT_HUMAN_ANSWER_UPDATE,
+            payload
+        );
+    });
+});

--- a/src/temporal/humanAnswerSubmit.ts
+++ b/src/temporal/humanAnswerSubmit.ts
@@ -1,0 +1,54 @@
+import type { TemporalRecoveryClient } from './temporalRecoveryScan';
+
+export const DEFAULT_HUMAN_ANSWER_UPDATE = 'forge.human_answer.submit';
+
+export interface HumanAnswerSubmitPayload {
+    question_id: string;
+    node_id: string;
+    answers: Record<string, string>;
+}
+
+export interface HumanAnswerSubmitClient {
+    executeUpdate(
+        namespace: string,
+        workflowId: string,
+        runId: string,
+        updateName: string,
+        payload: HumanAnswerSubmitPayload
+    ): Promise<void>;
+}
+
+export function createHumanAnswerSubmitClient(
+    recoveryClient: TemporalRecoveryClient
+): HumanAnswerSubmitClient {
+    return {
+        async executeUpdate(namespace, workflowId, runId, updateName, payload) {
+            await recoveryClient.executeWorkflowUpdate(
+                namespace,
+                workflowId,
+                runId,
+                updateName,
+                payload
+            );
+        },
+    };
+}
+
+export async function submitHumanAnswer(
+    client: HumanAnswerSubmitClient,
+    input: {
+        namespace: string;
+        workflowId: string;
+        runId: string;
+        updateName?: string;
+        payload: HumanAnswerSubmitPayload;
+    }
+): Promise<void> {
+    await client.executeUpdate(
+        input.namespace,
+        input.workflowId,
+        input.runId,
+        input.updateName ?? DEFAULT_HUMAN_ANSWER_UPDATE,
+        input.payload
+    );
+}

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -118,6 +118,25 @@ export {
     registerTemporalLocalSupervisor,
     shutdownTemporalLocalSupervisor,
 } from './temporalWindowRegistry';
+export {
+    RUN_INDEX_MAX_COMPLETED_ENTRIES,
+    RUN_INDEX_RETENTION_DAYS,
+    RunIndexDuplicateKeyError,
+    WorkflowRunIndexStore,
+    buildRunIndexKey,
+    createRunIndexEntryKey,
+    purgeCompletedRunIndexEntries,
+    readWorkflowRunIndexFile,
+    resolveRunIndexPath,
+    writeWorkflowRunIndexFile,
+} from './workflowRunIndex';
+export type {
+    AppendWorkflowRunIndexEntryInput,
+    MarkWorkflowRunIndexTerminalInput,
+    RecoveryState,
+    WorkflowRunIndexEntry,
+    WorkflowRunIndexFile,
+} from './workflowRunIndex';
 export type {
     ChildProcessSpawnOptions,
     ChildProcessSpawner,

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -137,6 +137,43 @@ export type {
     WorkflowRunIndexEntry,
     WorkflowRunIndexFile,
 } from './workflowRunIndex';
+export {
+    RECOVERY_LOG_PREFIX,
+    buildExternalRecoveryConnectionOptions,
+    classifyTemporalRefreshError,
+    createTemporalRecoveryClient,
+    formatRecoveryLogLine,
+    markNonTerminalIndexEntriesUnreachable,
+    refreshIndexedRunFromTemporal,
+    runRecoveryScan,
+} from './temporalRecoveryScan';
+export type {
+    TemporalRecoveryClient,
+    TemporalRecoveryConnectionOptions,
+    TemporalRecoveryScanOptions,
+    TemporalRefreshOutcome,
+} from './temporalRecoveryScan';
+export {
+    hasRecoveryScanCompletedThisSession,
+    registerTemporalRecoveryCoordinator,
+    resetRecoveryScanSessionForTests,
+} from './temporalRecoveryCoordinator';
+export type {
+    CombinedReadinessSnapshot,
+    TemporalRecoveryCoordinator,
+    TemporalRecoveryCoordinatorConfig,
+} from './temporalRecoveryCoordinator';
+export {
+    buildProjectionFromTemporalDescribe,
+    isTerminalTemporalStatus,
+    readWorkflowRunProjection,
+    resolveProjectionPath,
+    writeWorkflowRunProjection,
+} from './workflowRunProjection';
+export type {
+    WorkflowExecutionStatusName,
+    WorkflowRunProjection,
+} from './workflowRunProjection';
 export type {
     ChildProcessSpawnOptions,
     ChildProcessSpawner,

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -95,14 +95,24 @@ export {
     formatWorkerStateTransitionLogLine,
     formatWorkerStatusBarSegment,
     formatWorkerUpgradeRestartLogLine,
+    formatRecoveryBadgeLabel,
+    formatCancelConfirmMessage,
+    formatRunActionsBlockedMessage,
+    formatHumanInputBlockedMessage,
+    formatOrphanedRunMessage,
+    formatRefreshFailedRunMessage,
+    formatNeedsInputBadgeLabel,
 } from './temporalPresentation';
 export {
     TEMPORAL_OUTPUT_CHANNEL_NAME,
     createTemporalOutputChannel,
+    getCombinedRecoveryReadinessSnapshot,
+    isCombinedRecoveryReady,
     notifyWorkflowBlockedByTemporal,
     notifyWorkflowBlockedByWorker,
     registerExternalTemporalHealthSurfaces,
     registerManagedLocalTemporalHealthSurfaces,
+    registerRecoveryReadinessListener,
     registerWorkerHealthSurfaces,
 } from './temporalHealthSurfaces';
 export {
@@ -145,6 +155,7 @@ export {
     formatRecoveryLogLine,
     markNonTerminalIndexEntriesUnreachable,
     refreshIndexedRunFromTemporal,
+    runManualRecoveryRefresh,
     runRecoveryScan,
 } from './temporalRecoveryScan';
 export type {
@@ -173,6 +184,7 @@ export {
 export type {
     WorkflowExecutionStatusName,
     WorkflowRunProjection,
+    PendingHumanQuestion,
 } from './workflowRunProjection';
 export type {
     ChildProcessSpawnOptions,

--- a/src/temporal/temporalHealthSurfaces.ts
+++ b/src/temporal/temporalHealthSurfaces.ts
@@ -71,6 +71,21 @@ function notifyRecoveryReadinessChanged(): void {
     });
 }
 
+export function getCombinedRecoveryReadinessSnapshot(): {
+    temporalReady: boolean;
+    workerReady: boolean;
+} {
+    return {
+        temporalReady: isTemporalReadyForRecovery(),
+        workerReady: workerState === 'ready',
+    };
+}
+
+export function isCombinedRecoveryReady(): boolean {
+    const snapshot = getCombinedRecoveryReadinessSnapshot();
+    return snapshot.temporalReady && snapshot.workerReady;
+}
+
 export function createTemporalOutputChannel(
     context: vscode.ExtensionContext
 ): vscode.OutputChannel {

--- a/src/temporal/temporalHealthSurfaces.ts
+++ b/src/temporal/temporalHealthSurfaces.ts
@@ -41,6 +41,35 @@ let externalState: ExternalTemporalHealthState = 'idle';
 let workerState: WorkerHealthState = 'idle';
 let workerReadyNotifiedThisSession = false;
 let statusBarMode: 'managedLocal' | 'external' = 'managedLocal';
+let recoveryReadinessListener:
+    | ((snapshot: { temporalReady: boolean; workerReady: boolean }) => void)
+    | undefined;
+
+export function registerRecoveryReadinessListener(
+    listener: (snapshot: { temporalReady: boolean; workerReady: boolean }) => void
+): () => void {
+    recoveryReadinessListener = listener;
+    notifyRecoveryReadinessChanged();
+    return () => {
+        if (recoveryReadinessListener === listener) {
+            recoveryReadinessListener = undefined;
+        }
+    };
+}
+
+function isTemporalReadyForRecovery(): boolean {
+    if (statusBarMode === 'managedLocal') {
+        return managedLocalState === 'ready';
+    }
+    return externalState === 'ready';
+}
+
+function notifyRecoveryReadinessChanged(): void {
+    recoveryReadinessListener?.({
+        temporalReady: isTemporalReadyForRecovery(),
+        workerReady: workerState === 'ready',
+    });
+}
 
 export function createTemporalOutputChannel(
     context: vscode.ExtensionContext
@@ -77,6 +106,7 @@ export function registerManagedLocalTemporalHealthSurfaces(
         updateStatusBar();
         logManagedLocalStateTransition(state, supervisor, outputChannel);
         notifyManagedLocalForState(state, supervisor);
+        notifyRecoveryReadinessChanged();
     };
 
     applyState(supervisor.getHealthState());
@@ -100,6 +130,7 @@ export function registerWorkerHealthSurfaces(
         updateStatusBar();
         logWorkerStateTransition(state, supervisor, outputChannel);
         notifyWorkerForState(state, supervisor);
+        notifyRecoveryReadinessChanged();
     };
 
     applyState(supervisor.getHealthState());
@@ -244,6 +275,7 @@ export function registerExternalTemporalHealthSurfaces(
     const applyState = (state: ExternalTemporalHealthState) => {
         externalState = state;
         updateStatusBar();
+        notifyRecoveryReadinessChanged();
 
         const settings = resolveSettings();
         const address = settings.address ?? 'unknown';

--- a/src/temporal/temporalPresentation.test.ts
+++ b/src/temporal/temporalPresentation.test.ts
@@ -176,4 +176,29 @@ describe('temporalPresentation', () => {
             );
         });
     });
+
+    describe('run recovery presentation copy', () => {
+        it('maps recovery states to run list badge labels and action copy', async () => {
+            const {
+                formatRecoveryBadgeLabel,
+                formatCancelConfirmMessage,
+                formatRunActionsBlockedMessage,
+                formatHumanInputBlockedMessage,
+                formatOrphanedRunMessage,
+                formatNeedsInputBadgeLabel,
+            } = await import('./temporalPresentation');
+
+            expect(formatRecoveryBadgeLabel('recovery_pending')).toBe('Recovering…');
+            expect(formatRecoveryBadgeLabel('refresh_failed')).toBe('Refresh failed');
+            expect(formatRecoveryBadgeLabel('orphaned')).toBe('Stale');
+            expect(formatRecoveryBadgeLabel('unreachable')).toBe('Waiting for Temporal…');
+            expect(formatCancelConfirmMessage('wf-1', 'run-1')).toContain('wf-1/run-1');
+            expect(formatRunActionsBlockedMessage()).toContain('Run actions are unavailable');
+            expect(formatHumanInputBlockedMessage()).toContain(
+                'Submit answers after the run finishes recovering'
+            );
+            expect(formatOrphanedRunMessage()).toContain('dismiss it from the run list');
+            expect(formatNeedsInputBadgeLabel()).toBe('Needs input');
+        });
+    });
 });

--- a/src/temporal/temporalPresentation.ts
+++ b/src/temporal/temporalPresentation.ts
@@ -249,3 +249,48 @@ export function formatWorkerStateTransitionLogLine(
         context.exitCode !== undefined ? ` exitCode=${context.exitCode}` : '';
     return `[forge.temporal.worker] state=${state} windowId=${context.windowId} taskQueue=${context.taskQueue} namespace=${context.namespace} mode=${context.mode} extensionVersion=${context.extensionVersion}${pidPart}${exitCodePart}`;
 }
+
+export function formatRecoveryBadgeLabel(
+    recoveryState: import('./workflowRunIndex').RecoveryState
+): string {
+    switch (recoveryState) {
+        case 'synced':
+            return 'Synced';
+        case 'recovery_pending':
+            return 'Recovering…';
+        case 'refresh_failed':
+            return 'Refresh failed';
+        case 'orphaned':
+            return 'Stale';
+        case 'unreachable':
+            return 'Waiting for Temporal…';
+    }
+}
+
+export function formatCancelConfirmMessage(workflowId: string, runId: string): string {
+    return `Cancel workflow run ${workflowId}/${runId}? This terminates execution in Temporal.`;
+}
+
+export function formatRunActionsBlockedMessage(): string {
+    return 'Run actions are unavailable until recovery finishes. See Forge Temporal output.';
+}
+
+export function formatHumanInputBlockedMessage(): string {
+    return 'Submit answers after the run finishes recovering.';
+}
+
+export function formatOrphanedRunMessage(): string {
+    return 'This run is no longer in Temporal. You can dismiss it from the run list.';
+}
+
+export function formatRefreshFailedRunMessage(
+    workflowId: string,
+    runId: string,
+    reason: string
+): string {
+    return `Could not refresh run ${workflowId}/${runId} — ${reason}. Try **Forge: Refresh workflow runs**.`;
+}
+
+export function formatNeedsInputBadgeLabel(): string {
+    return 'Needs input';
+}

--- a/src/temporal/temporalRecoveryCoordinator.test.ts
+++ b/src/temporal/temporalRecoveryCoordinator.test.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    hasRecoveryScanCompletedThisSession,
+    registerTemporalRecoveryCoordinator,
+    resetRecoveryScanSessionForTests,
+} from './temporalRecoveryCoordinator';
+import type { TemporalRecoveryClient } from './temporalRecoveryScan';
+import { WorkflowRunIndexStore } from './workflowRunIndex';
+
+const tempDirs: string[] = [];
+
+function createTempGlobalStorage(): { globalStoragePath: string; windowId: string } {
+    const globalStoragePath = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-recovery-coordinator-'));
+    tempDirs.push(globalStoragePath);
+    return { globalStoragePath, windowId: 'window-coordinator-1' };
+}
+
+function createMockClient(): TemporalRecoveryClient {
+    return {
+        describeWorkflow: vi.fn(async () => ({
+            status: { name: 'RUNNING', code: 1 },
+            closeTime: undefined,
+        })),
+        fetchHistory: vi.fn(async () => ({ events: [] })),
+        close: vi.fn(async () => undefined),
+    };
+}
+
+afterEach(() => {
+    resetRecoveryScanSessionForTests();
+    while (tempDirs.length > 0) {
+        const tempDir = tempDirs.pop();
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('temporalRecoveryCoordinator', () => {
+    it('marks entries unreachable before combined readiness and scans once when ready', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const seedStore = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        seedStore.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        const client = createMockClient();
+        const createRecoveryClient = vi.fn(async () => client);
+
+        const coordinator = registerTemporalRecoveryCoordinator(
+            {
+                subscriptions: [],
+            } as import('vscode').ExtensionContext,
+            {
+                windowId,
+                globalStoragePath,
+                log: () => undefined,
+                createRecoveryClient,
+            }
+        );
+
+        const readStore = () => new WorkflowRunIndexStore(globalStoragePath, windowId);
+
+        coordinator.onReadinessChanged({ temporalReady: false, workerReady: false });
+        expect(readStore().getEntry('forge-local:wf-1:run-1')?.recoveryState).toBe('unreachable');
+
+        coordinator.onReadinessChanged({ temporalReady: true, workerReady: true });
+        await vi.waitFor(() => {
+            expect(hasRecoveryScanCompletedThisSession()).toBe(true);
+        });
+
+        expect(readStore().getEntry('forge-local:wf-1:run-1')?.recoveryState).toBe('synced');
+        expect(createRecoveryClient).toHaveBeenCalledOnce();
+
+        coordinator.onReadinessChanged({ temporalReady: true, workerReady: true });
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(createRecoveryClient).toHaveBeenCalledOnce();
+    });
+});

--- a/src/temporal/temporalRecoveryCoordinator.test.ts
+++ b/src/temporal/temporalRecoveryCoordinator.test.ts
@@ -25,6 +25,8 @@ function createMockClient(): TemporalRecoveryClient {
             closeTime: undefined,
         })),
         fetchHistory: vi.fn(async () => ({ events: [] })),
+        terminateWorkflow: vi.fn(async () => undefined),
+        executeWorkflowUpdate: vi.fn(async () => undefined),
         close: vi.fn(async () => undefined),
     };
 }

--- a/src/temporal/temporalRecoveryCoordinator.test.ts
+++ b/src/temporal/temporalRecoveryCoordinator.test.ts
@@ -9,6 +9,10 @@ import {
 } from './temporalRecoveryCoordinator';
 import type { TemporalRecoveryClient } from './temporalRecoveryScan';
 import { WorkflowRunIndexStore } from './workflowRunIndex';
+import {
+    getWorkflowRunRecoveryContext,
+    registerWorkflowRunRecoveryContext,
+} from './workflowRunRecoveryService';
 
 const tempDirs: string[] = [];
 
@@ -86,5 +90,58 @@ describe('temporalRecoveryCoordinator', () => {
         coordinator.onReadinessChanged({ temporalReady: true, workerReady: true });
         await new Promise((resolve) => setTimeout(resolve, 20));
         expect(createRecoveryClient).toHaveBeenCalledOnce();
+    });
+
+    it('updates the shared recovery context index store after automatic scan', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const sharedIndexStore = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        sharedIndexStore.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-shared',
+            runId: 'run-shared',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        registerWorkflowRunRecoveryContext({
+            windowId,
+            globalStoragePath,
+            log: () => undefined,
+            indexStore: sharedIndexStore,
+            isReady: () => true,
+            createRecoveryClient: async () => createMockClient(),
+        });
+
+        const coordinator = registerTemporalRecoveryCoordinator(
+            {
+                subscriptions: [],
+            } as import('vscode').ExtensionContext,
+            {
+                windowId,
+                globalStoragePath,
+                indexStore: sharedIndexStore,
+                log: () => undefined,
+                createRecoveryClient: async () => createMockClient(),
+            }
+        );
+
+        coordinator.onReadinessChanged({ temporalReady: false, workerReady: false });
+        expect(
+            getWorkflowRunRecoveryContext()?.indexStore.getEntry('forge-local:wf-shared:run-shared')
+                ?.recoveryState
+        ).toBe('unreachable');
+
+        coordinator.onReadinessChanged({ temporalReady: true, workerReady: true });
+        await vi.waitFor(() => {
+            expect(
+                getWorkflowRunRecoveryContext()?.indexStore.getEntry(
+                    'forge-local:wf-shared:run-shared'
+                )?.recoveryState
+            ).toBe('synced');
+        });
+
+        expect(getWorkflowRunRecoveryContext()?.indexStore).toBe(sharedIndexStore);
     });
 });

--- a/src/temporal/temporalRecoveryCoordinator.ts
+++ b/src/temporal/temporalRecoveryCoordinator.ts
@@ -1,0 +1,118 @@
+import type * as vscode from 'vscode';
+import { getRegisteredStoredApiKeyReader } from './externalCredentials';
+import { resolveExternalApiKey, resolveExternalSettings } from './externalSettings';
+import { resolveManagedLocalSettings } from './managedLocalSettings';
+import { resolveTemporalMode } from './temporalSettings';
+import {
+    buildExternalRecoveryConnectionOptions,
+    createTemporalRecoveryClient,
+    markNonTerminalIndexEntriesUnreachable,
+    runRecoveryScan,
+    type TemporalRecoveryClient,
+} from './temporalRecoveryScan';
+import { WorkflowRunIndexStore } from './workflowRunIndex';
+
+export interface CombinedReadinessSnapshot {
+    temporalReady: boolean;
+    workerReady: boolean;
+}
+
+export interface TemporalRecoveryCoordinatorConfig {
+    windowId: string;
+    globalStoragePath: string;
+    log: (line: string) => void;
+    resolveMode?: () => ReturnType<typeof resolveTemporalMode>;
+    createRecoveryClient?: () => Promise<TemporalRecoveryClient>;
+}
+
+export interface TemporalRecoveryCoordinator {
+    onReadinessChanged(snapshot: CombinedReadinessSnapshot): void;
+}
+
+let recoveryScanCompletedThisSession = false;
+let recoveryScanInFlight: Promise<void> | undefined;
+
+export function resetRecoveryScanSessionForTests(): void {
+    recoveryScanCompletedThisSession = false;
+    recoveryScanInFlight = undefined;
+}
+
+export function hasRecoveryScanCompletedThisSession(): boolean {
+    return recoveryScanCompletedThisSession;
+}
+
+function isCombinedReadinessSatisfied(snapshot: CombinedReadinessSnapshot): boolean {
+    return snapshot.temporalReady && snapshot.workerReady;
+}
+
+async function defaultCreateRecoveryClient(
+    config: TemporalRecoveryCoordinatorConfig
+): Promise<TemporalRecoveryClient> {
+    const mode = (config.resolveMode ?? resolveTemporalMode)();
+
+    if (mode === 'external') {
+        const settings = resolveExternalSettings();
+        const apiKey = await resolveExternalApiKey(getRegisteredStoredApiKeyReader());
+        return createTemporalRecoveryClient({
+            mode,
+            namespace: settings.namespace ?? 'default',
+            externalConnectionOptions: buildExternalRecoveryConnectionOptions(settings, apiKey),
+        });
+    }
+
+    const settings = resolveManagedLocalSettings({
+        globalStoragePath: config.globalStoragePath,
+        windowId: config.windowId,
+    });
+
+    return createTemporalRecoveryClient({
+        mode,
+        namespace: settings.namespace,
+        grpcPort: settings.grpcPort,
+    });
+}
+
+export function registerTemporalRecoveryCoordinator(
+    _context: vscode.ExtensionContext,
+    config: TemporalRecoveryCoordinatorConfig
+): TemporalRecoveryCoordinator {
+    const indexStore = new WorkflowRunIndexStore(config.globalStoragePath, config.windowId);
+    const createClient = config.createRecoveryClient ?? (() => defaultCreateRecoveryClient(config));
+
+    const onReadinessChanged = (snapshot: CombinedReadinessSnapshot): void => {
+        if (!isCombinedReadinessSatisfied(snapshot)) {
+            if (recoveryScanInFlight) {
+                return;
+            }
+            markNonTerminalIndexEntriesUnreachable(indexStore, {
+                windowId: config.windowId,
+                log: config.log,
+            });
+            return;
+        }
+
+        if (recoveryScanCompletedThisSession || recoveryScanInFlight) {
+            return;
+        }
+
+        recoveryScanInFlight = runRecoveryScan({
+            windowId: config.windowId,
+            globalStoragePath: config.globalStoragePath,
+            indexStore,
+            log: config.log,
+            createClient,
+        })
+            .then(() => {
+                recoveryScanCompletedThisSession = true;
+            })
+            .catch((error) => {
+                const message = error instanceof Error ? error.message : String(error);
+                config.log(`[forge.temporal.recovery] windowId=${config.windowId} recoveryState=refresh_failed errorCode=SCAN_FAILED message=${message}`);
+            })
+            .finally(() => {
+                recoveryScanInFlight = undefined;
+            });
+    };
+
+    return { onReadinessChanged };
+}

--- a/src/temporal/temporalRecoveryCoordinator.ts
+++ b/src/temporal/temporalRecoveryCoordinator.ts
@@ -11,6 +11,7 @@ import {
     type TemporalRecoveryClient,
 } from './temporalRecoveryScan';
 import { WorkflowRunIndexStore } from './workflowRunIndex';
+import { notifyWorkflowRunIndexChanged } from './workflowRunRecoveryService';
 
 export interface CombinedReadinessSnapshot {
     temporalReady: boolean;
@@ -104,6 +105,7 @@ export function registerTemporalRecoveryCoordinator(
         })
             .then(() => {
                 recoveryScanCompletedThisSession = true;
+                notifyWorkflowRunIndexChanged();
             })
             .catch((error) => {
                 const message = error instanceof Error ? error.message : String(error);

--- a/src/temporal/temporalRecoveryCoordinator.ts
+++ b/src/temporal/temporalRecoveryCoordinator.ts
@@ -22,6 +22,7 @@ export interface TemporalRecoveryCoordinatorConfig {
     windowId: string;
     globalStoragePath: string;
     log: (line: string) => void;
+    indexStore?: WorkflowRunIndexStore;
     resolveMode?: () => ReturnType<typeof resolveTemporalMode>;
     createRecoveryClient?: () => Promise<TemporalRecoveryClient>;
 }
@@ -77,7 +78,8 @@ export function registerTemporalRecoveryCoordinator(
     _context: vscode.ExtensionContext,
     config: TemporalRecoveryCoordinatorConfig
 ): TemporalRecoveryCoordinator {
-    const indexStore = new WorkflowRunIndexStore(config.globalStoragePath, config.windowId);
+    const indexStore =
+        config.indexStore ?? new WorkflowRunIndexStore(config.globalStoragePath, config.windowId);
     const createClient = config.createRecoveryClient ?? (() => defaultCreateRecoveryClient(config));
 
     const onReadinessChanged = (snapshot: CombinedReadinessSnapshot): void => {

--- a/src/temporal/temporalRecoveryScan.test.ts
+++ b/src/temporal/temporalRecoveryScan.test.ts
@@ -38,6 +38,8 @@ function createMockClient(
             closeTime: undefined,
         })),
         fetchHistory: vi.fn(async () => ({ events: [] })),
+        terminateWorkflow: vi.fn(async () => undefined),
+        executeWorkflowUpdate: vi.fn(async () => undefined),
         close: vi.fn(async () => undefined),
         ...behavior,
     };
@@ -207,5 +209,39 @@ describe('temporalRecoveryScan', () => {
         expect(client.describeWorkflow).toHaveBeenCalledOnce();
         expect(client.close).toHaveBeenCalledOnce();
         expect(store.getEntry('forge-local:wf-1:run-1')?.recoveryState).toBe('synced');
+    });
+
+    it('manual refresh re-scans all indexed entries including terminal runs within retention', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-active',
+            runId: 'run-active',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+        store.markTerminal('forge-local:wf-active:run-active', {
+            completedAt: '2026-06-01T00:00:00.000Z',
+            recoveryState: 'synced',
+        });
+
+        const client = createMockClient();
+        const logs: string[] = [];
+
+        const { runManualRecoveryRefresh } = await import('./temporalRecoveryScan');
+        await runManualRecoveryRefresh({
+            windowId,
+            globalStoragePath,
+            indexStore: store,
+            log: (line) => logs.push(line),
+            createClient: async () => client,
+        });
+
+        expect(client.describeWorkflow).toHaveBeenCalledOnce();
+        expect(logs.some((line) => line.includes('Manual refresh started count=1'))).toBe(true);
+        expect(logs.some((line) => line.includes('Recovered 1 workflow run(s).'))).toBe(true);
     });
 });

--- a/src/temporal/temporalRecoveryScan.test.ts
+++ b/src/temporal/temporalRecoveryScan.test.ts
@@ -1,0 +1,211 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    classifyTemporalRefreshError,
+    markNonTerminalIndexEntriesUnreachable,
+    refreshIndexedRunFromTemporal,
+    runRecoveryScan,
+    type TemporalRecoveryClient,
+} from './temporalRecoveryScan';
+import { readWorkflowRunProjection, resolveProjectionPath } from './workflowRunProjection';
+import { WorkflowRunIndexStore } from './workflowRunIndex';
+
+const tempDirs: string[] = [];
+
+function createTempGlobalStorage(): { globalStoragePath: string; windowId: string } {
+    const globalStoragePath = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-recovery-scan-'));
+    tempDirs.push(globalStoragePath);
+    return { globalStoragePath, windowId: 'window-recovery-1' };
+}
+
+function createGrpcServiceError(code: grpcStatus, message: string): Error {
+    return Object.assign(new Error(message), {
+        code,
+        details: message,
+        metadata: {},
+    });
+}
+
+function createMockClient(
+    behavior: Partial<TemporalRecoveryClient> = {}
+): TemporalRecoveryClient {
+    return {
+        describeWorkflow: vi.fn(async () => ({
+            status: { name: 'RUNNING', code: 1 },
+            closeTime: undefined,
+        })),
+        fetchHistory: vi.fn(async () => ({ events: [] })),
+        close: vi.fn(async () => undefined),
+        ...behavior,
+    };
+}
+
+afterEach(() => {
+    while (tempDirs.length > 0) {
+        const tempDir = tempDirs.pop();
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('temporalRecoveryScan', () => {
+    it('classifies NOT_FOUND as orphaned and other errors as refresh_failed', () => {
+        expect(
+            classifyTemporalRefreshError(
+                createGrpcServiceError(grpcStatus.NOT_FOUND, 'workflow not found')
+            ).recoveryState
+        ).toBe('orphaned');
+
+        expect(
+            classifyTemporalRefreshError(
+                createGrpcServiceError(grpcStatus.PERMISSION_DENIED, 'permission denied')
+            ).recoveryState
+        ).toBe('refresh_failed');
+    });
+
+    it('marks non-terminal entries unreachable when readiness is not satisfied', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        const logs: string[] = [];
+        const updated = markNonTerminalIndexEntriesUnreachable(store, {
+            windowId,
+            log: (line) => logs.push(line),
+        });
+
+        expect(updated).toBe(1);
+        expect(store.getEntry('forge-local:wf-1:run-1')?.recoveryState).toBe('unreachable');
+        expect(logs.some((line) => line.includes('recoveryState=unreachable'))).toBe(true);
+    });
+
+    it('refreshes a non-terminal entry to synced and overwrites stale projection', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        const projectionPath = resolveProjectionPath(
+            globalStoragePath,
+            windowId,
+            'forge-local:wf-1:run-1'
+        );
+        fs.mkdirSync(path.dirname(projectionPath), { recursive: true });
+        fs.writeFileSync(
+            projectionPath,
+            JSON.stringify({
+                ...entry,
+                recoveryState: 'recovery_pending',
+                lastSyncedAt: '2020-01-01T00:00:00.000Z',
+                temporalStatus: 'UNKNOWN',
+                completedNodeIds: [],
+                skippedNodeIds: [],
+                cancelled: false,
+                validationSummaries: [],
+                pendingHumanQuestions: [],
+            })
+        );
+
+        const client = createMockClient();
+        const logs: string[] = [];
+
+        const outcome = await refreshIndexedRunFromTemporal(entry, {
+            indexStore: store,
+            globalStoragePath,
+            windowId,
+            client,
+            log: (line) => logs.push(line),
+            now: () => new Date('2026-06-10T12:00:00.000Z'),
+        });
+
+        expect(outcome.recoveryState).toBe('synced');
+        expect(store.getEntry('forge-local:wf-1:run-1')?.recoveryState).toBe('synced');
+        expect(store.getEntry('forge-local:wf-1:run-1')?.lastSyncedAt).toBe('2026-06-10T12:00:00.000Z');
+
+        const projection = readWorkflowRunProjection(projectionPath);
+        expect(projection?.recoveryState).toBe('synced');
+        expect(projection?.lastSyncedAt).toBe('2026-06-10T12:00:00.000Z');
+        expect(projection?.temporalStatus).toBe('RUNNING');
+        expect(client.describeWorkflow).toHaveBeenCalledOnce();
+        expect(client.fetchHistory).toHaveBeenCalledOnce();
+        expect(logs.some((line) => line.includes('recoveryState=synced'))).toBe(true);
+    });
+
+    it('sets orphaned when Temporal reports workflow not found', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-missing',
+            runId: 'run-missing',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        const client = createMockClient({
+            describeWorkflow: vi.fn(async () => {
+                throw createGrpcServiceError(grpcStatus.NOT_FOUND, 'workflow not found');
+            }),
+        });
+
+        const outcome = await refreshIndexedRunFromTemporal(entry, {
+            indexStore: store,
+            globalStoragePath,
+            windowId,
+            client,
+            log: () => undefined,
+        });
+
+        expect(outcome.recoveryState).toBe('orphaned');
+        expect(store.getEntry('forge-local:wf-missing:run-missing')?.recoveryState).toBe('orphaned');
+    });
+
+    it('runs recovery scan for each non-terminal entry and closes the Temporal client', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        const client = createMockClient();
+
+        await runRecoveryScan({
+            windowId,
+            globalStoragePath,
+            indexStore: store,
+            log: () => undefined,
+            createClient: async () => client,
+        });
+
+        expect(client.describeWorkflow).toHaveBeenCalledOnce();
+        expect(client.close).toHaveBeenCalledOnce();
+        expect(store.getEntry('forge-local:wf-1:run-1')?.recoveryState).toBe('synced');
+    });
+});

--- a/src/temporal/temporalRecoveryScan.ts
+++ b/src/temporal/temporalRecoveryScan.ts
@@ -1,0 +1,364 @@
+import { status as grpcStatus } from '@grpc/grpc-js';
+import { Client, Connection, isGrpcServiceError } from '@temporalio/client';
+import { buildManagedLocalGrpcAddress } from './devServerLaunch';
+import { buildExternalConnectionOptions } from './externalConnection';
+import { formatSafeForLog } from './secretRedaction';
+import type { TemporalMode } from './temporalSettings';
+import {
+    buildProjectionFromTemporalDescribe,
+    resolveProjectionPath,
+    writeWorkflowRunProjection,
+} from './workflowRunProjection';
+import {
+    WorkflowRunIndexStore,
+    buildRunIndexKey,
+    createRunIndexEntryKey,
+    type RecoveryState,
+    type WorkflowRunIndexEntry,
+} from './workflowRunIndex';
+
+export const RECOVERY_LOG_PREFIX = '[forge.temporal.recovery]';
+
+export interface TemporalRecoveryConnectionOptions {
+    mode: TemporalMode;
+    namespace: string;
+    grpcPort?: number;
+    externalAddress?: string;
+    externalConnectionOptions?: import('@temporalio/client').ConnectionOptions;
+}
+
+export interface TemporalRecoveryClient {
+    describeWorkflow(
+        namespace: string,
+        workflowId: string,
+        runId: string
+    ): Promise<import('@temporalio/client').WorkflowExecutionDescription>;
+    fetchHistory(
+        namespace: string,
+        workflowId: string,
+        runId: string
+    ): Promise<unknown>;
+    close(): Promise<void>;
+}
+
+export interface TemporalRecoveryScanOptions {
+    windowId: string;
+    globalStoragePath: string;
+    indexStore: WorkflowRunIndexStore;
+    log: (line: string) => void;
+    now?: () => Date;
+    createClient?: () => Promise<TemporalRecoveryClient>;
+}
+
+export interface TemporalRefreshOutcome {
+    key: string;
+    recoveryState: RecoveryState;
+    terminal: boolean;
+    errorCode?: string;
+}
+
+export function classifyTemporalRefreshError(error: unknown): {
+    recoveryState: 'orphaned' | 'refresh_failed';
+    errorCode: string;
+} {
+    const queue: unknown[] = [error];
+
+    while (queue.length > 0) {
+        const current = queue.shift();
+        if (current === undefined || current === null) {
+            continue;
+        }
+
+        if (isGrpcServiceError(current)) {
+            if (current.code === grpcStatus.NOT_FOUND) {
+                return { recoveryState: 'orphaned', errorCode: 'NOT_FOUND' };
+            }
+            return {
+                recoveryState: 'refresh_failed',
+                errorCode: grpcStatus[current.code] ?? `GRPC_${current.code}`,
+            };
+        }
+
+        if (current instanceof Error) {
+            if (current.cause !== undefined) {
+                queue.push(current.cause);
+            }
+            const message = current.message.toLowerCase();
+            if (message.includes('not found') || message.includes('workflow not found')) {
+                return { recoveryState: 'orphaned', errorCode: 'NOT_FOUND' };
+            }
+        }
+    }
+
+    return { recoveryState: 'refresh_failed', errorCode: 'REFRESH_FAILED' };
+}
+
+export function formatRecoveryLogLine(input: {
+    windowId: string;
+    namespace: string;
+    workflowId: string;
+    runId: string;
+    recoveryState: RecoveryState;
+    errorCode?: string;
+    message?: string;
+}): string {
+    const parts = [
+        RECOVERY_LOG_PREFIX,
+        `windowId=${input.windowId}`,
+        `namespace=${input.namespace}`,
+        `workflowId=${input.workflowId}`,
+        `runId=${input.runId}`,
+        `recoveryState=${input.recoveryState}`,
+    ];
+
+    if (input.errorCode) {
+        parts.push(`errorCode=${input.errorCode}`);
+    }
+
+    if (input.message) {
+        parts.push(`message=${input.message}`);
+    }
+
+    return formatSafeForLog(parts.join(' '));
+}
+
+export async function createTemporalRecoveryClient(
+    options: TemporalRecoveryConnectionOptions
+): Promise<TemporalRecoveryClient> {
+    let connection: Connection | undefined;
+
+    if (options.mode === 'external') {
+        if (!options.externalConnectionOptions) {
+            throw new Error('External Temporal connection options are required.');
+        }
+        connection = await Connection.connect(options.externalConnectionOptions);
+    } else {
+        if (options.grpcPort === undefined) {
+            throw new Error('Managed-local gRPC port is required.');
+        }
+        connection = await Connection.connect({
+            address: buildManagedLocalGrpcAddress(options.grpcPort),
+        });
+    }
+
+    const client = new Client({
+        connection,
+        namespace: options.namespace,
+    });
+
+    return {
+        async describeWorkflow(namespace, workflowId, runId) {
+            const scopedClient =
+                namespace === options.namespace
+                    ? client
+                    : new Client({ connection: connection!, namespace });
+            const handle = scopedClient.workflow.getHandle(workflowId, runId);
+            return handle.describe();
+        },
+        async fetchHistory(namespace, workflowId, runId) {
+            const scopedClient =
+                namespace === options.namespace
+                    ? client
+                    : new Client({ connection: connection!, namespace });
+            const handle = scopedClient.workflow.getHandle(workflowId, runId);
+            return handle.fetchHistory();
+        },
+        async close() {
+            await connection?.close().catch(() => undefined);
+        },
+    };
+}
+
+export function buildExternalRecoveryConnectionOptions(
+    settings: import('./externalSettings').ResolvedExternalSettings,
+    apiKey: string | undefined
+): import('@temporalio/client').ConnectionOptions {
+    return buildExternalConnectionOptions(settings, apiKey);
+}
+
+export async function refreshIndexedRunFromTemporal(
+    entry: WorkflowRunIndexEntry,
+    input: {
+        indexStore: WorkflowRunIndexStore;
+        globalStoragePath: string;
+        windowId: string;
+        client: TemporalRecoveryClient;
+        log: (line: string) => void;
+        now?: () => Date;
+    }
+): Promise<TemporalRefreshOutcome> {
+    const key = createRunIndexEntryKey(entry);
+    const syncedAt = (input.now ?? (() => new Date()))().toISOString();
+
+    input.indexStore.updateEntry(key, { recoveryState: 'recovery_pending' });
+    input.log(
+        formatRecoveryLogLine({
+            windowId: input.windowId,
+            namespace: entry.namespace,
+            workflowId: entry.workflowId,
+            runId: entry.runId,
+            recoveryState: 'recovery_pending',
+        })
+    );
+
+    try {
+        const description = await input.client.describeWorkflow(
+            entry.namespace,
+            entry.workflowId,
+            entry.runId
+        );
+        await input.client.fetchHistory(entry.namespace, entry.workflowId, entry.runId);
+
+        const projection = buildProjectionFromTemporalDescribe(entry, description, 'synced', syncedAt);
+        const projectionPath = resolveProjectionPath(
+            input.globalStoragePath,
+            input.windowId,
+            key
+        );
+        writeWorkflowRunProjection(projectionPath, projection);
+
+        if (projection.terminal) {
+            input.indexStore.markTerminal(key, {
+                recoveryState: 'synced',
+                lastSyncedAt: syncedAt,
+                completedAt: description.closeTime?.toISOString() ?? syncedAt,
+            });
+        } else {
+            input.indexStore.updateEntry(key, {
+                recoveryState: 'synced',
+                lastSyncedAt: syncedAt,
+            });
+        }
+
+        input.log(
+            formatRecoveryLogLine({
+                windowId: input.windowId,
+                namespace: entry.namespace,
+                workflowId: entry.workflowId,
+                runId: entry.runId,
+                recoveryState: 'synced',
+            })
+        );
+
+        return {
+            key,
+            recoveryState: 'synced',
+            terminal: projection.terminal,
+        };
+    } catch (error) {
+        const classified = classifyTemporalRefreshError(error);
+        input.indexStore.updateEntry(key, { recoveryState: classified.recoveryState });
+
+        const message = error instanceof Error ? error.message : String(error);
+        input.log(
+            formatRecoveryLogLine({
+                windowId: input.windowId,
+                namespace: entry.namespace,
+                workflowId: entry.workflowId,
+                runId: entry.runId,
+                recoveryState: classified.recoveryState,
+                errorCode: classified.errorCode,
+                message,
+            })
+        );
+
+        return {
+            key,
+            recoveryState: classified.recoveryState,
+            terminal: false,
+            errorCode: classified.errorCode,
+        };
+    }
+}
+
+export function markNonTerminalIndexEntriesUnreachable(
+    indexStore: WorkflowRunIndexStore,
+    input: {
+        windowId: string;
+        log: (line: string) => void;
+    }
+): number {
+    let updated = 0;
+
+    for (const entry of indexStore.listEntries()) {
+        if (entry.terminal || entry.recoveryState === 'orphaned' || entry.recoveryState === 'unreachable') {
+            continue;
+        }
+
+        const key = buildRunIndexKey(entry.namespace, entry.workflowId, entry.runId);
+        indexStore.updateEntry(key, { recoveryState: 'unreachable' });
+        input.log(
+            formatRecoveryLogLine({
+                windowId: input.windowId,
+                namespace: entry.namespace,
+                workflowId: entry.workflowId,
+                runId: entry.runId,
+                recoveryState: 'unreachable',
+            })
+        );
+        updated += 1;
+    }
+
+    return updated;
+}
+
+export async function runRecoveryScan(
+    options: TemporalRecoveryScanOptions
+): Promise<TemporalRefreshOutcome[]> {
+    const nonTerminalEntries = options.indexStore
+        .listEntries()
+        .filter((entry) => !entry.terminal);
+
+    options.log(
+        formatSafeForLog(
+            `${RECOVERY_LOG_PREFIX} windowId=${options.windowId} message=Recovering workflow runs for this window… count=${nonTerminalEntries.length}`
+        )
+    );
+
+    if (nonTerminalEntries.length === 0) {
+        return [];
+    }
+
+    const client = await (options.createClient?.() ??
+        Promise.reject(new Error('Temporal recovery client factory is not configured.')));
+
+    const outcomes: TemporalRefreshOutcome[] = [];
+    try {
+        for (const entry of nonTerminalEntries) {
+            outcomes.push(
+                await refreshIndexedRunFromTemporal(entry, {
+                    indexStore: options.indexStore,
+                    globalStoragePath: options.globalStoragePath,
+                    windowId: options.windowId,
+                    client,
+                    log: options.log,
+                    now: options.now,
+                })
+            );
+        }
+    } finally {
+        await client.close();
+    }
+
+    const summary = outcomes.reduce(
+        (counts, outcome) => {
+            counts[outcome.recoveryState] += 1;
+            return counts;
+        },
+        {
+            synced: 0,
+            orphaned: 0,
+            refresh_failed: 0,
+            recovery_pending: 0,
+            unreachable: 0,
+        } as Record<RecoveryState, number>
+    );
+
+    options.log(
+        formatSafeForLog(
+            `${RECOVERY_LOG_PREFIX} windowId=${options.windowId} message=Recovery scan complete synced=${summary.synced} orphaned=${summary.orphaned} refresh_failed=${summary.refresh_failed}`
+        )
+    );
+
+    return outcomes;
+}

--- a/src/temporal/temporalRecoveryScan.ts
+++ b/src/temporal/temporalRecoveryScan.ts
@@ -38,6 +38,19 @@ export interface TemporalRecoveryClient {
         workflowId: string,
         runId: string
     ): Promise<unknown>;
+    terminateWorkflow(
+        namespace: string,
+        workflowId: string,
+        runId: string,
+        reason?: string
+    ): Promise<void>;
+    executeWorkflowUpdate(
+        namespace: string,
+        workflowId: string,
+        runId: string,
+        updateName: string,
+        payload: unknown
+    ): Promise<void>;
     close(): Promise<void>;
 }
 
@@ -162,6 +175,22 @@ export async function createTemporalRecoveryClient(
                     : new Client({ connection: connection!, namespace });
             const handle = scopedClient.workflow.getHandle(workflowId, runId);
             return handle.fetchHistory();
+        },
+        async terminateWorkflow(namespace, workflowId, runId, reason) {
+            const scopedClient =
+                namespace === options.namespace
+                    ? client
+                    : new Client({ connection: connection!, namespace });
+            const handle = scopedClient.workflow.getHandle(workflowId, runId);
+            await handle.terminate(reason);
+        },
+        async executeWorkflowUpdate(namespace, workflowId, runId, updateName, payload) {
+            const scopedClient =
+                namespace === options.namespace
+                    ? client
+                    : new Client({ connection: connection!, namespace });
+            const handle = scopedClient.workflow.getHandle(workflowId, runId);
+            await handle.executeUpdate(updateName, { args: [payload] });
         },
         async close() {
             await connection?.close().catch(() => undefined);
@@ -302,6 +331,75 @@ export function markNonTerminalIndexEntriesUnreachable(
     return updated;
 }
 
+function summarizeRefreshOutcomes(outcomes: TemporalRefreshOutcome[]): Record<RecoveryState, number> {
+    return outcomes.reduce(
+        (counts, outcome) => {
+            counts[outcome.recoveryState] += 1;
+            return counts;
+        },
+        {
+            synced: 0,
+            orphaned: 0,
+            refresh_failed: 0,
+            recovery_pending: 0,
+            unreachable: 0,
+        } as Record<RecoveryState, number>
+    );
+}
+
+function logRecoveryScanSummary(
+    windowId: string,
+    summary: Record<RecoveryState, number>,
+    log: (line: string) => void,
+    options?: { manualRefresh?: boolean }
+): void {
+    log(
+        formatSafeForLog(
+            `${RECOVERY_LOG_PREFIX} windowId=${windowId} message=Recovery scan complete synced=${summary.synced} orphaned=${summary.orphaned} refresh_failed=${summary.refresh_failed}`
+        )
+    );
+
+    if (options?.manualRefresh && summary.synced > 0) {
+        log(
+            formatSafeForLog(
+                `${RECOVERY_LOG_PREFIX} windowId=${windowId} message=Recovered ${summary.synced} workflow run(s).`
+            )
+        );
+    }
+}
+
+async function refreshIndexedEntries(
+    entries: WorkflowRunIndexEntry[],
+    options: TemporalRecoveryScanOptions
+): Promise<TemporalRefreshOutcome[]> {
+    if (entries.length === 0) {
+        return [];
+    }
+
+    const client = await (options.createClient?.() ??
+        Promise.reject(new Error('Temporal recovery client factory is not configured.')));
+
+    const outcomes: TemporalRefreshOutcome[] = [];
+    try {
+        for (const entry of entries) {
+            outcomes.push(
+                await refreshIndexedRunFromTemporal(entry, {
+                    indexStore: options.indexStore,
+                    globalStoragePath: options.globalStoragePath,
+                    windowId: options.windowId,
+                    client,
+                    log: options.log,
+                    now: options.now,
+                })
+            );
+        }
+    } finally {
+        await client.close();
+    }
+
+    return outcomes;
+}
+
 export async function runRecoveryScan(
     options: TemporalRecoveryScanOptions
 ): Promise<TemporalRefreshOutcome[]> {
@@ -319,46 +417,36 @@ export async function runRecoveryScan(
         return [];
     }
 
-    const client = await (options.createClient?.() ??
-        Promise.reject(new Error('Temporal recovery client factory is not configured.')));
+    const outcomes = await refreshIndexedEntries(nonTerminalEntries, options);
+    const summary = summarizeRefreshOutcomes(outcomes);
+    logRecoveryScanSummary(options.windowId, summary, options.log);
 
-    const outcomes: TemporalRefreshOutcome[] = [];
-    try {
-        for (const entry of nonTerminalEntries) {
-            outcomes.push(
-                await refreshIndexedRunFromTemporal(entry, {
-                    indexStore: options.indexStore,
-                    globalStoragePath: options.globalStoragePath,
-                    windowId: options.windowId,
-                    client,
-                    log: options.log,
-                    now: options.now,
-                })
-            );
-        }
-    } finally {
-        await client.close();
-    }
+    return outcomes;
+}
 
-    const summary = outcomes.reduce(
-        (counts, outcome) => {
-            counts[outcome.recoveryState] += 1;
-            return counts;
-        },
-        {
-            synced: 0,
-            orphaned: 0,
-            refresh_failed: 0,
-            recovery_pending: 0,
-            unreachable: 0,
-        } as Record<RecoveryState, number>
-    );
+export async function runManualRecoveryRefresh(
+    options: TemporalRecoveryScanOptions
+): Promise<TemporalRefreshOutcome[]> {
+    const entries = options.indexStore.listEntries();
 
     options.log(
         formatSafeForLog(
-            `${RECOVERY_LOG_PREFIX} windowId=${options.windowId} message=Recovery scan complete synced=${summary.synced} orphaned=${summary.orphaned} refresh_failed=${summary.refresh_failed}`
+            `${RECOVERY_LOG_PREFIX} windowId=${options.windowId} message=Manual refresh started count=${entries.length}`
         )
     );
+
+    if (entries.length === 0) {
+        options.log(
+            formatSafeForLog(
+                `${RECOVERY_LOG_PREFIX} windowId=${options.windowId} message=No indexed workflow runs to refresh.`
+            )
+        );
+        return [];
+    }
+
+    const outcomes = await refreshIndexedEntries(entries, options);
+    const summary = summarizeRefreshOutcomes(outcomes);
+    logRecoveryScanSummary(options.windowId, summary, options.log, { manualRefresh: true });
 
     return outcomes;
 }

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -21,6 +21,7 @@ import {
 import { registerTemporalRecoveryCoordinator } from './temporalRecoveryCoordinator';
 import { formatPersistencePathForDisplay } from './temporalPresentation';
 import { isCombinedRecoveryReady } from './temporalHealthSurfaces';
+import { WorkflowRunIndexStore } from './workflowRunIndex';
 import {
     createWorkflowRunRecoveryContext,
     registerWorkflowRunRecoveryContext,
@@ -109,9 +110,13 @@ export function registerTemporalLocalSupervisor(
     const outputChannel = createTemporalOutputChannel(context);
     const mode = resolveTemporalMode();
 
+    const globalStoragePath = context.globalStorageUri.fsPath;
+    const workflowRunIndexStore = new WorkflowRunIndexStore(globalStoragePath, windowId);
+
     const recoveryCoordinator = registerTemporalRecoveryCoordinator(context, {
         windowId,
-        globalStoragePath: context.globalStorageUri.fsPath,
+        globalStoragePath,
+        indexStore: workflowRunIndexStore,
         log: (line) => {
             outputChannel.appendLine(line);
         },
@@ -128,6 +133,7 @@ export function registerTemporalLocalSupervisor(
                 outputChannel.appendLine(line);
             },
             isReady: isCombinedRecoveryReady,
+            indexStore: workflowRunIndexStore,
         })
     );
     registerWorkflowRunRecoveryCommands(context);

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -15,8 +15,10 @@ import {
     createTemporalOutputChannel,
     registerExternalTemporalHealthSurfaces,
     registerManagedLocalTemporalHealthSurfaces,
+    registerRecoveryReadinessListener,
     registerWorkerHealthSurfaces,
 } from './temporalHealthSurfaces';
+import { registerTemporalRecoveryCoordinator } from './temporalRecoveryCoordinator';
 import { formatPersistencePathForDisplay } from './temporalPresentation';
 import type {
     ExternalTemporalSupervisorConfig,
@@ -100,6 +102,19 @@ export function registerTemporalLocalSupervisor(
     const windowId = vscode.env.sessionId;
     const outputChannel = createTemporalOutputChannel(context);
     const mode = resolveTemporalMode();
+
+    const recoveryCoordinator = registerTemporalRecoveryCoordinator(context, {
+        windowId,
+        globalStoragePath: context.globalStorageUri.fsPath,
+        log: (line) => {
+            outputChannel.appendLine(line);
+        },
+    });
+
+    const disposeRecoveryListener = registerRecoveryReadinessListener((snapshot) => {
+        recoveryCoordinator.onReadinessChanged(snapshot);
+    });
+    context.subscriptions.push({ dispose: disposeRecoveryListener });
 
     if (mode === 'external') {
         const externalConfig: ExternalTemporalSupervisorConfig = {

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -20,11 +20,17 @@ import {
 } from './temporalHealthSurfaces';
 import { registerTemporalRecoveryCoordinator } from './temporalRecoveryCoordinator';
 import { formatPersistencePathForDisplay } from './temporalPresentation';
+import { isCombinedRecoveryReady } from './temporalHealthSurfaces';
+import {
+    createWorkflowRunRecoveryContext,
+    registerWorkflowRunRecoveryContext,
+} from './workflowRunRecoveryService';
 import type {
     ExternalTemporalSupervisorConfig,
     ManagedLocalSupervisorConfig,
     TemporalWorkerSupervisorConfig,
 } from './types';
+import { registerWorkflowRunRecoveryCommands } from '../commands/WorkflowRunRecoveryCommands';
 
 let localSupervisor: TemporalLocalSupervisor | undefined;
 let externalSupervisor: ExternalTemporalSupervisor | undefined;
@@ -115,6 +121,16 @@ export function registerTemporalLocalSupervisor(
         recoveryCoordinator.onReadinessChanged(snapshot);
     });
     context.subscriptions.push({ dispose: disposeRecoveryListener });
+
+    registerWorkflowRunRecoveryContext(
+        createWorkflowRunRecoveryContext(context, {
+            log: (line) => {
+                outputChannel.appendLine(line);
+            },
+            isReady: isCombinedRecoveryReady,
+        })
+    );
+    registerWorkflowRunRecoveryCommands(context);
 
     if (mode === 'external') {
         const externalConfig: ExternalTemporalSupervisorConfig = {

--- a/src/temporal/workflowRunActions.test.ts
+++ b/src/temporal/workflowRunActions.test.ts
@@ -1,0 +1,196 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    cancelWorkflowRun,
+    dismissOrphanedWorkflowRun,
+    evaluateHumanInputSubmit,
+    evaluateWorkflowRunAction,
+    isHumanInputRequired,
+} from './workflowRunActions';
+import { readWorkflowRunProjection, resolveProjectionPath } from './workflowRunProjection';
+import { WorkflowRunIndexStore } from './workflowRunIndex';
+import type { TemporalRecoveryClient } from './temporalRecoveryScan';
+import {
+    formatHumanInputBlockedMessage,
+    formatRunActionsBlockedMessage,
+} from './temporalPresentation';
+
+const tempDirs: string[] = [];
+
+function createTempGlobalStorage(): { globalStoragePath: string; windowId: string } {
+    const globalStoragePath = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-run-actions-'));
+    tempDirs.push(globalStoragePath);
+    return { globalStoragePath, windowId: 'window-actions-1' };
+}
+
+function createEntry(store: WorkflowRunIndexStore) {
+    return store.appendRunStartEntry({
+        namespace: 'forge-local',
+        workflowId: 'wf-1',
+        runId: 'run-1',
+        taskQueue: 'forge-workflows',
+        workflow_id: 'refine-issue',
+        repositoryRoot: '/repo',
+        mode: 'managedLocal',
+    });
+}
+
+function createMockClient(): TemporalRecoveryClient {
+    return {
+        describeWorkflow: vi.fn(async () => ({
+            status: { name: 'TERMINATED', code: 5 },
+            closeTime: new Date('2026-06-10T12:00:00.000Z'),
+        })),
+        fetchHistory: vi.fn(async () => ({ events: [] })),
+        terminateWorkflow: vi.fn(async () => undefined),
+        executeWorkflowUpdate: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+    };
+}
+
+afterEach(() => {
+    while (tempDirs.length > 0) {
+        const tempDir = tempDirs.pop();
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('workflowRunActions', () => {
+    it('blocks cancel, dismiss, and human input while recovery is pending', () => {
+        const entry = {
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal' as const,
+            startedAt: '2026-06-01T00:00:00.000Z',
+            recoveryState: 'recovery_pending' as const,
+            terminal: false,
+        };
+
+        expect(evaluateWorkflowRunAction(entry, 'cancel').reason).toBe(
+            formatRunActionsBlockedMessage()
+        );
+        expect(evaluateWorkflowRunAction(entry, 'dismiss').allowed).toBe(false);
+        expect(evaluateHumanInputSubmit(entry).reason).toBe(formatHumanInputBlockedMessage());
+    });
+
+    it('allows cancel only for synced non-terminal runs', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = createEntry(store);
+
+        expect(evaluateWorkflowRunAction(entry, 'cancel').allowed).toBe(false);
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'synced' });
+        const synced = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(synced, 'cancel').allowed).toBe(true);
+    });
+
+    it('allows dismiss only for orphaned entries', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = createEntry(store);
+
+        expect(evaluateWorkflowRunAction(entry, 'dismiss').allowed).toBe(false);
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'orphaned' });
+        const orphaned = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(orphaned, 'dismiss').allowed).toBe(true);
+    });
+
+    it('detects human input required from pending questions on synced runs', () => {
+        const projection = {
+            namespace: 'forge-local',
+            workflowId: 'wf-1',
+            runId: 'run-1',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal' as const,
+            recoveryState: 'synced' as const,
+            lastSyncedAt: '2026-06-10T00:00:00.000Z',
+            terminal: false,
+            temporalStatus: 'RUNNING' as const,
+            completedNodeIds: [],
+            skippedNodeIds: [],
+            cancelled: false,
+            validationSummaries: [],
+            pendingHumanQuestions: [
+                {
+                    question_id: 'user_verification_batch',
+                    node_id: 'human-1',
+                    node_name: 'Verify answers',
+                },
+            ],
+        };
+
+        expect(isHumanInputRequired(projection)).toBe(true);
+        expect(
+            evaluateHumanInputSubmit(
+                {
+                    ...projection,
+                    startedAt: projection.lastSyncedAt,
+                    recoveryState: 'synced',
+                    terminal: false,
+                },
+                projection
+            ).allowed
+        ).toBe(true);
+    });
+
+    it('cancels a synced run through Temporal terminate and marks the index terminal', async () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = createEntry(store);
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'synced' });
+        const synced = store.getEntry('forge-local:wf-1:run-1')!;
+        const client = createMockClient();
+
+        await cancelWorkflowRun(synced, {
+            indexStore: store,
+            globalStoragePath,
+            windowId,
+            client,
+            now: () => new Date('2026-06-10T12:00:00.000Z'),
+        });
+
+        expect(client.terminateWorkflow).toHaveBeenCalledOnce();
+        expect(store.getEntry('forge-local:wf-1:run-1')?.terminal).toBe(true);
+        const projection = readWorkflowRunProjection(
+            resolveProjectionPath(globalStoragePath, windowId, 'forge-local:wf-1:run-1')
+        );
+        expect(projection?.temporalStatus).toBe('TERMINATED');
+    });
+
+    it('dismisses orphaned entries and removes projection files without Temporal calls', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = createEntry(store);
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'orphaned' });
+        const orphaned = store.getEntry('forge-local:wf-1:run-1')!;
+        const projectionPath = resolveProjectionPath(
+            globalStoragePath,
+            windowId,
+            'forge-local:wf-1:run-1'
+        );
+        fs.mkdirSync(path.dirname(projectionPath), { recursive: true });
+        fs.writeFileSync(projectionPath, '{}');
+
+        expect(
+            dismissOrphanedWorkflowRun(orphaned, {
+                indexStore: store,
+                globalStoragePath,
+                windowId,
+            })
+        ).toBe(true);
+        expect(store.listEntries()).toHaveLength(0);
+        expect(fs.existsSync(projectionPath)).toBe(false);
+    });
+});

--- a/src/temporal/workflowRunActions.ts
+++ b/src/temporal/workflowRunActions.ts
@@ -1,0 +1,179 @@
+import fs from 'fs';
+import {
+    buildProjectionFromTemporalDescribe,
+    readWorkflowRunProjection,
+    resolveProjectionPath,
+    writeWorkflowRunProjection,
+    type WorkflowRunProjection,
+} from './workflowRunProjection';
+import {
+    createRunIndexEntryKey,
+    type RecoveryState,
+    type WorkflowRunIndexEntry,
+    type WorkflowRunIndexStore,
+} from './workflowRunIndex';
+import {
+    formatHumanInputBlockedMessage,
+    formatOrphanedRunMessage,
+    formatRunActionsBlockedMessage,
+} from './temporalPresentation';
+import type { TemporalRecoveryClient } from './temporalRecoveryScan';
+
+export type WorkflowRunAction = 'cancel' | 'dismiss' | 'humanInput';
+
+const BLOCKED_RECOVERY_STATES = new Set<RecoveryState>([
+    'recovery_pending',
+    'refresh_failed',
+    'unreachable',
+]);
+
+export function isHumanInputRequired(projection: WorkflowRunProjection | undefined): boolean {
+    return (projection?.pendingHumanQuestions.length ?? 0) > 0 && !projection?.terminal;
+}
+
+export function evaluateWorkflowRunAction(
+    entry: WorkflowRunIndexEntry,
+    action: WorkflowRunAction,
+    projection?: WorkflowRunProjection
+): { allowed: boolean; reason?: string } {
+    if (action === 'dismiss') {
+        if (entry.recoveryState !== 'orphaned') {
+            return {
+                allowed: false,
+                reason: formatOrphanedRunMessage(),
+            };
+        }
+        return { allowed: true };
+    }
+
+    if (BLOCKED_RECOVERY_STATES.has(entry.recoveryState)) {
+        return {
+            allowed: false,
+            reason: formatRunActionsBlockedMessage(),
+        };
+    }
+
+    if (entry.recoveryState !== 'synced') {
+        return {
+            allowed: false,
+            reason: formatRunActionsBlockedMessage(),
+        };
+    }
+
+    if (action === 'cancel') {
+        if (entry.terminal) {
+            return {
+                allowed: false,
+                reason: 'This run has already finished.',
+            };
+        }
+        return { allowed: true };
+    }
+
+    if (action === 'humanInput') {
+        if (!isHumanInputRequired(projection)) {
+            return {
+                allowed: false,
+                reason: 'No questions are waiting for this run.',
+            };
+        }
+        return { allowed: true };
+    }
+
+    return { allowed: false, reason: formatRunActionsBlockedMessage() };
+}
+
+export function evaluateHumanInputSubmit(
+    entry: WorkflowRunIndexEntry,
+    projection?: WorkflowRunProjection
+): { allowed: boolean; reason?: string } {
+    if (BLOCKED_RECOVERY_STATES.has(entry.recoveryState)) {
+        return {
+            allowed: false,
+            reason: formatHumanInputBlockedMessage(),
+        };
+    }
+
+    if (entry.recoveryState !== 'synced') {
+        return {
+            allowed: false,
+            reason: formatHumanInputBlockedMessage(),
+        };
+    }
+
+    if (!isHumanInputRequired(projection)) {
+        return {
+            allowed: false,
+            reason: 'No questions are waiting for this run.',
+        };
+    }
+
+    return { allowed: true };
+}
+
+export async function cancelWorkflowRun(
+    entry: WorkflowRunIndexEntry,
+    input: {
+        indexStore: WorkflowRunIndexStore;
+        globalStoragePath: string;
+        windowId: string;
+        client: TemporalRecoveryClient;
+        now?: () => Date;
+    }
+): Promise<void> {
+    const key = createRunIndexEntryKey(entry);
+    const syncedAt = (input.now ?? (() => new Date()))().toISOString();
+
+    await input.client.terminateWorkflow(
+        entry.namespace,
+        entry.workflowId,
+        entry.runId,
+        'Cancelled by Forge operator'
+    );
+
+    const description = await input.client.describeWorkflow(
+        entry.namespace,
+        entry.workflowId,
+        entry.runId
+    );
+    const projection = buildProjectionFromTemporalDescribe(entry, description, 'synced', syncedAt);
+    const projectionPath = resolveProjectionPath(input.globalStoragePath, input.windowId, key);
+    writeWorkflowRunProjection(projectionPath, projection);
+
+    input.indexStore.markTerminal(key, {
+        recoveryState: 'synced',
+        lastSyncedAt: syncedAt,
+        completedAt: description.closeTime?.toISOString() ?? syncedAt,
+    });
+}
+
+export function dismissOrphanedWorkflowRun(
+    entry: WorkflowRunIndexEntry,
+    input: {
+        indexStore: WorkflowRunIndexStore;
+        globalStoragePath: string;
+        windowId: string;
+    }
+): boolean {
+    const key = createRunIndexEntryKey(entry);
+    const removed = input.indexStore.removeEntry(key);
+    if (!removed) {
+        return false;
+    }
+
+    const projectionPath = resolveProjectionPath(input.globalStoragePath, input.windowId, key);
+    if (fs.existsSync(projectionPath)) {
+        fs.rmSync(projectionPath, { force: true });
+    }
+
+    return true;
+}
+
+export function readProjectionForEntry(
+    entry: WorkflowRunIndexEntry,
+    globalStoragePath: string,
+    windowId: string
+): WorkflowRunProjection | undefined {
+    const key = createRunIndexEntryKey(entry);
+    return readWorkflowRunProjection(resolveProjectionPath(globalStoragePath, windowId, key));
+}

--- a/src/temporal/workflowRunIndex.test.ts
+++ b/src/temporal/workflowRunIndex.test.ts
@@ -82,6 +82,24 @@ describe('workflowRunIndex', () => {
         expect(reloaded.listEntries()[0]?.repositoryRoot).toBe('/workspace/repo');
     });
 
+    it('removes entries for orphaned dismissal', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-remove',
+            runId: 'run-remove',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal',
+        });
+
+        expect(store.removeEntry('forge-local:wf-remove:run-remove')).toBe(true);
+        expect(store.listEntries()).toHaveLength(0);
+        expect(store.removeEntry('forge-local:wf-remove:run-remove')).toBe(false);
+    });
+
     it('rejects duplicate index keys on insert', () => {
         const { globalStoragePath, windowId } = createTempGlobalStorage();
         const store = new WorkflowRunIndexStore(globalStoragePath, windowId);

--- a/src/temporal/workflowRunIndex.test.ts
+++ b/src/temporal/workflowRunIndex.test.ts
@@ -1,0 +1,252 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    buildRunIndexKey,
+    purgeCompletedRunIndexEntries,
+    readWorkflowRunIndexFile,
+    resolveRunIndexPath,
+    RunIndexDuplicateKeyError,
+    WorkflowRunIndexEntry,
+    WorkflowRunIndexStore,
+    writeWorkflowRunIndexFile,
+} from './workflowRunIndex';
+
+const tempDirs: string[] = [];
+
+function createTempGlobalStorage(): { globalStoragePath: string; windowId: string } {
+    const globalStoragePath = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-run-index-'));
+    tempDirs.push(globalStoragePath);
+    return { globalStoragePath, windowId: 'window-test-1' };
+}
+
+function makeEntry(overrides: Partial<WorkflowRunIndexEntry> = {}): WorkflowRunIndexEntry {
+    return {
+        namespace: 'forge-local',
+        workflowId: 'wf-1',
+        runId: 'run-1',
+        taskQueue: 'forge-workflows',
+        workflow_id: 'refine-issue',
+        repositoryRoot: '/repo',
+        mode: 'managedLocal',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        recoveryState: 'recovery_pending',
+        terminal: false,
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    while (tempDirs.length > 0) {
+        const tempDir = tempDirs.pop();
+        if (tempDir) {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('workflowRunIndex', () => {
+    it('resolves index path under global storage and window id', () => {
+        expect(resolveRunIndexPath('/storage', 'window-abc')).toBe(
+            path.join('/storage', 'temporal', 'window-abc', 'run-index.json')
+        );
+    });
+
+    it('builds composite index keys', () => {
+        expect(buildRunIndexKey('ns', 'workflow', 'run')).toBe('ns:workflow:run');
+    });
+
+    it('appends run start entries with recovery_pending and non-terminal defaults', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+
+        const entry = store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-abc',
+            runId: 'run-xyz',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/workspace/repo',
+            mode: 'managedLocal',
+            startedAt: '2026-06-01T12:00:00.000Z',
+        });
+
+        expect(entry.recoveryState).toBe('recovery_pending');
+        expect(entry.terminal).toBe(false);
+        expect(entry.startedAt).toBe('2026-06-01T12:00:00.000Z');
+        expect(fs.existsSync(store.path)).toBe(true);
+
+        const reloaded = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        expect(reloaded.listEntries()).toHaveLength(1);
+        expect(reloaded.listEntries()[0]?.repositoryRoot).toBe('/workspace/repo');
+    });
+
+    it('rejects duplicate index keys on insert', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const input = {
+            namespace: 'forge-local',
+            workflowId: 'wf-dup',
+            runId: 'run-dup',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'managedLocal' as const,
+        };
+
+        store.appendRunStartEntry(input);
+
+        expect(() => store.appendRunStartEntry(input)).toThrow(RunIndexDuplicateKeyError);
+    });
+
+    it('marks entries terminal with completedAt and optional projection fields', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const key = store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-term',
+            runId: 'run-term',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo',
+            mode: 'external',
+        });
+
+        const indexKey = buildRunIndexKey('forge-local', 'wf-term', 'run-term');
+        const updated = store.markTerminal(indexKey, {
+            completedAt: '2026-06-02T00:00:00.000Z',
+            lastSyncedAt: '2026-06-02T00:00:01.000Z',
+            recoveryState: 'synced',
+        });
+
+        expect(updated.terminal).toBe(true);
+        expect(updated.completedAt).toBe('2026-06-02T00:00:00.000Z');
+        expect(updated.lastSyncedAt).toBe('2026-06-02T00:00:01.000Z');
+        expect(updated.recoveryState).toBe('synced');
+        expect(key.runId).toBe('run-term');
+    });
+
+    it('lists all window runs for recovery and run list consumers', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+
+        store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-a',
+            runId: 'run-a',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo-a',
+            mode: 'managedLocal',
+        });
+        store.appendRunStartEntry({
+            namespace: 'forge-local',
+            workflowId: 'wf-b',
+            runId: 'run-b',
+            taskQueue: 'forge-workflows',
+            workflow_id: 'build-from-github',
+            repositoryRoot: '/repo-b',
+            mode: 'external',
+        });
+
+        const listed = store.listEntries();
+        expect(listed).toHaveLength(2);
+        expect(listed.map((entry) => entry.repositoryRoot).sort()).toEqual(['/repo-a', '/repo-b']);
+    });
+
+    it('purges completed entries older than 30 days on load', () => {
+        const now = new Date('2026-06-10T00:00:00.000Z');
+        const oldCompletedAt = '2026-04-01T00:00:00.000Z';
+        const recentCompletedAt = '2026-06-01T00:00:00.000Z';
+
+        const entries = {
+            'ns:wf-old:run-old': makeEntry({
+                workflowId: 'wf-old',
+                runId: 'run-old',
+                terminal: true,
+                completedAt: oldCompletedAt,
+            }),
+            'ns:wf-new:run-new': makeEntry({
+                workflowId: 'wf-new',
+                runId: 'run-new',
+                terminal: true,
+                completedAt: recentCompletedAt,
+            }),
+            'ns:wf-active:run-active': makeEntry({
+                workflowId: 'wf-active',
+                runId: 'run-active',
+                terminal: false,
+            }),
+        };
+
+        const purged = purgeCompletedRunIndexEntries(entries, now);
+        expect(Object.keys(purged).sort()).toEqual(['ns:wf-active:run-active', 'ns:wf-new:run-new']);
+    });
+
+    it('never auto-purges non-terminal entries', () => {
+        const now = new Date('2026-06-10T00:00:00.000Z');
+        const entries = {
+            'ns:wf-active:run-active': makeEntry({
+                workflowId: 'wf-active',
+                runId: 'run-active',
+                startedAt: '2020-01-01T00:00:00.000Z',
+                terminal: false,
+            }),
+        };
+
+        const purged = purgeCompletedRunIndexEntries(entries, now);
+        expect(purged['ns:wf-active:run-active']).toBeDefined();
+    });
+
+    it('caps completed entries at 100 by oldest completedAt', () => {
+        const now = new Date('2026-06-10T00:00:00.000Z');
+        const entries: Record<string, WorkflowRunIndexEntry> = {};
+
+        const retentionStart = Date.parse('2026-05-11T00:00:00.000Z');
+        for (let index = 0; index < 101; index += 1) {
+            const key = `ns:wf-${index}:run-${index}`;
+            entries[key] = makeEntry({
+                workflowId: `wf-${index}`,
+                runId: `run-${index}`,
+                terminal: true,
+                completedAt: new Date(retentionStart + index * 60_000).toISOString(),
+            });
+        }
+
+        const purged = purgeCompletedRunIndexEntries(entries, now);
+        const completed = Object.values(purged).filter((entry) => entry.terminal);
+        expect(completed).toHaveLength(100);
+        expect(purged['ns:wf-0:run-0']).toBeUndefined();
+        expect(purged['ns:wf-100:run-100']).toBeDefined();
+    });
+
+    it('persists retention purge on store load when file contains stale completed entries', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const indexPath = resolveRunIndexPath(globalStoragePath, windowId);
+
+        writeWorkflowRunIndexFile(indexPath, {
+            version: 1,
+            entries: {
+                'ns:wf-old:run-old': makeEntry({
+                    workflowId: 'wf-old',
+                    runId: 'run-old',
+                    terminal: true,
+                    completedAt: '2026-01-01T00:00:00.000Z',
+                }),
+                'ns:wf-active:run-active': makeEntry({
+                    workflowId: 'wf-active',
+                    runId: 'run-active',
+                    terminal: false,
+                }),
+            },
+        });
+
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        expect(store.listEntries()).toHaveLength(1);
+        expect(store.listEntries()[0]?.workflowId).toBe('wf-active');
+
+        const reloaded = readWorkflowRunIndexFile(indexPath);
+        expect(Object.keys(reloaded.entries)).toEqual(['ns:wf-active:run-active']);
+    });
+});

--- a/src/temporal/workflowRunIndex.ts
+++ b/src/temporal/workflowRunIndex.ts
@@ -1,0 +1,260 @@
+import fs from 'fs';
+import path from 'path';
+import type { TemporalMode } from './temporalSettings';
+
+export type RecoveryState =
+    | 'synced'
+    | 'recovery_pending'
+    | 'refresh_failed'
+    | 'orphaned'
+    | 'unreachable';
+
+export interface WorkflowRunIndexEntry {
+    namespace: string;
+    workflowId: string;
+    runId: string;
+    taskQueue: string;
+    workflow_id: string;
+    repositoryRoot: string;
+    mode: TemporalMode;
+    startedAt: string;
+    completedAt?: string;
+    lastSyncedAt?: string;
+    recoveryState: RecoveryState;
+    terminal: boolean;
+}
+
+export interface WorkflowRunIndexFile {
+    version: 1;
+    entries: Record<string, WorkflowRunIndexEntry>;
+}
+
+export const RUN_INDEX_RETENTION_DAYS = 30;
+export const RUN_INDEX_MAX_COMPLETED_ENTRIES = 100;
+
+const RUN_INDEX_RETENTION_MS = RUN_INDEX_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+export class RunIndexDuplicateKeyError extends Error {
+    readonly key: string;
+
+    constructor(key: string) {
+        super(`Workflow run index already contains entry for key: ${key}`);
+        this.name = 'RunIndexDuplicateKeyError';
+        this.key = key;
+    }
+}
+
+export function resolveRunIndexPath(globalStoragePath: string, windowId: string): string {
+    return path.join(globalStoragePath, 'temporal', windowId, 'run-index.json');
+}
+
+export function buildRunIndexKey(namespace: string, workflowId: string, runId: string): string {
+    return `${namespace}:${workflowId}:${runId}`;
+}
+
+export function createRunIndexEntryKey(entry: Pick<WorkflowRunIndexEntry, 'namespace' | 'workflowId' | 'runId'>): string {
+    return buildRunIndexKey(entry.namespace, entry.workflowId, entry.runId);
+}
+
+function parseRunIndexFile(raw: string): WorkflowRunIndexFile {
+    const parsed = JSON.parse(raw) as WorkflowRunIndexFile;
+    if (parsed.version !== 1 || typeof parsed.entries !== 'object' || parsed.entries === null) {
+        throw new Error('Invalid workflow run index file');
+    }
+    return parsed;
+}
+
+function emptyRunIndexFile(): WorkflowRunIndexFile {
+    return { version: 1, entries: {} };
+}
+
+function atomicWriteFile(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tempPath, content, 'utf8');
+    fs.renameSync(tempPath, filePath);
+}
+
+function completedAtMillis(entry: WorkflowRunIndexEntry): number {
+    if (!entry.completedAt) {
+        return 0;
+    }
+    return new Date(entry.completedAt).getTime();
+}
+
+export function purgeCompletedRunIndexEntries(
+    entries: Record<string, WorkflowRunIndexEntry>,
+    now: Date = new Date()
+): Record<string, WorkflowRunIndexEntry> {
+    const cutoff = now.getTime() - RUN_INDEX_RETENTION_MS;
+    const retained: Record<string, WorkflowRunIndexEntry> = {};
+    const completedWithinRetention: Array<[string, WorkflowRunIndexEntry]> = [];
+
+    for (const [key, entry] of Object.entries(entries)) {
+        if (!entry.terminal) {
+            retained[key] = entry;
+            continue;
+        }
+
+        const completedAt = completedAtMillis(entry);
+        if (completedAt >= cutoff) {
+            completedWithinRetention.push([key, entry]);
+        }
+    }
+
+    completedWithinRetention.sort((left, right) => completedAtMillis(left[1]) - completedAtMillis(right[1]));
+
+    const overflow = completedWithinRetention.length - RUN_INDEX_MAX_COMPLETED_ENTRIES;
+    const keptCompleted =
+        overflow > 0
+            ? completedWithinRetention.slice(overflow)
+            : completedWithinRetention;
+
+    for (const [key, entry] of keptCompleted) {
+        retained[key] = entry;
+    }
+
+    return retained;
+}
+
+export function readWorkflowRunIndexFile(indexPath: string): WorkflowRunIndexFile {
+    if (!fs.existsSync(indexPath)) {
+        return emptyRunIndexFile();
+    }
+
+    try {
+        return parseRunIndexFile(fs.readFileSync(indexPath, 'utf8'));
+    } catch {
+        return emptyRunIndexFile();
+    }
+}
+
+export function writeWorkflowRunIndexFile(indexPath: string, index: WorkflowRunIndexFile): void {
+    atomicWriteFile(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+}
+
+export interface AppendWorkflowRunIndexEntryInput {
+    namespace: string;
+    workflowId: string;
+    runId: string;
+    taskQueue: string;
+    workflow_id: string;
+    repositoryRoot: string;
+    mode: TemporalMode;
+    startedAt?: string;
+}
+
+export interface MarkWorkflowRunIndexTerminalInput {
+    completedAt?: string;
+    lastSyncedAt?: string;
+    recoveryState?: RecoveryState;
+}
+
+export class WorkflowRunIndexStore {
+    private readonly indexPath: string;
+    private index: WorkflowRunIndexFile;
+
+    constructor(globalStoragePath: string, windowId: string) {
+        this.indexPath = resolveRunIndexPath(globalStoragePath, windowId);
+        this.index = readWorkflowRunIndexFile(this.indexPath);
+        this.applyRetentionPurge();
+    }
+
+    get path(): string {
+        return this.indexPath;
+    }
+
+    listEntries(): WorkflowRunIndexEntry[] {
+        return Object.values(this.index.entries);
+    }
+
+    getEntry(key: string): WorkflowRunIndexEntry | undefined {
+        return this.index.entries[key];
+    }
+
+    appendRunStartEntry(input: AppendWorkflowRunIndexEntryInput): WorkflowRunIndexEntry {
+        const key = buildRunIndexKey(input.namespace, input.workflowId, input.runId);
+        if (this.index.entries[key]) {
+            throw new RunIndexDuplicateKeyError(key);
+        }
+
+        const entry: WorkflowRunIndexEntry = {
+            namespace: input.namespace,
+            workflowId: input.workflowId,
+            runId: input.runId,
+            taskQueue: input.taskQueue,
+            workflow_id: input.workflow_id,
+            repositoryRoot: input.repositoryRoot,
+            mode: input.mode,
+            startedAt: input.startedAt ?? new Date().toISOString(),
+            recoveryState: 'recovery_pending',
+            terminal: false,
+        };
+
+        this.index.entries[key] = entry;
+        this.persist();
+        return entry;
+    }
+
+    markTerminal(
+        key: string,
+        update: MarkWorkflowRunIndexTerminalInput = {}
+    ): WorkflowRunIndexEntry {
+        const entry = this.index.entries[key];
+        if (!entry) {
+            throw new Error(`Workflow run index entry not found for key: ${key}`);
+        }
+
+        const updated: WorkflowRunIndexEntry = {
+            ...entry,
+            terminal: true,
+            completedAt: update.completedAt ?? new Date().toISOString(),
+            ...(update.lastSyncedAt !== undefined ? { lastSyncedAt: update.lastSyncedAt } : {}),
+            ...(update.recoveryState !== undefined ? { recoveryState: update.recoveryState } : {}),
+        };
+
+        this.index.entries[key] = updated;
+        this.persist();
+        return updated;
+    }
+
+    updateEntry(
+        key: string,
+        update: Partial<
+            Pick<WorkflowRunIndexEntry, 'lastSyncedAt' | 'recoveryState' | 'completedAt' | 'terminal'>
+        >
+    ): WorkflowRunIndexEntry {
+        const entry = this.index.entries[key];
+        if (!entry) {
+            throw new Error(`Workflow run index entry not found for key: ${key}`);
+        }
+
+        const updated: WorkflowRunIndexEntry = {
+            ...entry,
+            ...update,
+        };
+
+        this.index.entries[key] = updated;
+        this.persist();
+        return updated;
+    }
+
+    reload(): void {
+        this.index = readWorkflowRunIndexFile(this.indexPath);
+        this.applyRetentionPurge();
+    }
+
+    private applyRetentionPurge(now: Date = new Date()): void {
+        const purged = purgeCompletedRunIndexEntries(this.index.entries, now);
+        if (Object.keys(purged).length === Object.keys(this.index.entries).length) {
+            return;
+        }
+
+        this.index = { version: 1, entries: purged };
+        this.persist();
+    }
+
+    private persist(): void {
+        writeWorkflowRunIndexFile(this.indexPath, this.index);
+    }
+}

--- a/src/temporal/workflowRunIndex.ts
+++ b/src/temporal/workflowRunIndex.ts
@@ -239,6 +239,16 @@ export class WorkflowRunIndexStore {
         return updated;
     }
 
+    removeEntry(key: string): boolean {
+        if (!this.index.entries[key]) {
+            return false;
+        }
+
+        delete this.index.entries[key];
+        this.persist();
+        return true;
+    }
+
     reload(): void {
         this.index = readWorkflowRunIndexFile(this.indexPath);
         this.applyRetentionPurge();

--- a/src/temporal/workflowRunProjection.ts
+++ b/src/temporal/workflowRunProjection.ts
@@ -16,6 +16,12 @@ export type WorkflowExecutionStatusName =
     | 'PAUSED'
     | 'UNKNOWN';
 
+export interface PendingHumanQuestion {
+    question_id: string;
+    node_id: string;
+    node_name: string;
+}
+
 export interface WorkflowRunProjection {
     namespace: string;
     workflowId: string;
@@ -32,7 +38,7 @@ export interface WorkflowRunProjection {
     skippedNodeIds: string[];
     cancelled: boolean;
     validationSummaries: [];
-    pendingHumanQuestions: [];
+    pendingHumanQuestions: PendingHumanQuestion[];
 }
 
 const TERMINAL_TEMPORAL_STATUSES = new Set<WorkflowExecutionStatusName>([

--- a/src/temporal/workflowRunProjection.ts
+++ b/src/temporal/workflowRunProjection.ts
@@ -1,0 +1,112 @@
+import fs from 'fs';
+import path from 'path';
+import type { WorkflowExecutionDescription } from '@temporalio/client';
+import type { TemporalMode } from './temporalSettings';
+import type { RecoveryState, WorkflowRunIndexEntry } from './workflowRunIndex';
+
+export type WorkflowExecutionStatusName =
+    | 'UNSPECIFIED'
+    | 'RUNNING'
+    | 'COMPLETED'
+    | 'FAILED'
+    | 'CANCELLED'
+    | 'TERMINATED'
+    | 'CONTINUED_AS_NEW'
+    | 'TIMED_OUT'
+    | 'PAUSED'
+    | 'UNKNOWN';
+
+export interface WorkflowRunProjection {
+    namespace: string;
+    workflowId: string;
+    runId: string;
+    taskQueue: string;
+    workflow_id: string;
+    repositoryRoot: string;
+    mode: TemporalMode;
+    recoveryState: RecoveryState;
+    lastSyncedAt: string;
+    terminal: boolean;
+    temporalStatus: WorkflowExecutionStatusName;
+    completedNodeIds: string[];
+    skippedNodeIds: string[];
+    cancelled: boolean;
+    validationSummaries: [];
+    pendingHumanQuestions: [];
+}
+
+const TERMINAL_TEMPORAL_STATUSES = new Set<WorkflowExecutionStatusName>([
+    'COMPLETED',
+    'FAILED',
+    'CANCELLED',
+    'TERMINATED',
+    'TIMED_OUT',
+]);
+
+export function resolveProjectionPath(
+    globalStoragePath: string,
+    windowId: string,
+    indexKey: string
+): string {
+    const safeKey = indexKey.replace(/:/g, '__');
+    return path.join(globalStoragePath, 'temporal', windowId, 'projections', `${safeKey}.json`);
+}
+
+function atomicWriteFile(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tempPath, content, 'utf8');
+    fs.renameSync(tempPath, filePath);
+}
+
+export function readWorkflowRunProjection(projectionPath: string): WorkflowRunProjection | undefined {
+    if (!fs.existsSync(projectionPath)) {
+        return undefined;
+    }
+
+    try {
+        return JSON.parse(fs.readFileSync(projectionPath, 'utf8')) as WorkflowRunProjection;
+    } catch {
+        return undefined;
+    }
+}
+
+export function writeWorkflowRunProjection(
+    projectionPath: string,
+    projection: WorkflowRunProjection
+): void {
+    atomicWriteFile(projectionPath, `${JSON.stringify(projection, null, 2)}\n`);
+}
+
+export function isTerminalTemporalStatus(status: WorkflowExecutionStatusName): boolean {
+    return TERMINAL_TEMPORAL_STATUSES.has(status);
+}
+
+export function buildProjectionFromTemporalDescribe(
+    entry: WorkflowRunIndexEntry,
+    description: WorkflowExecutionDescription,
+    recoveryState: RecoveryState,
+    syncedAt: string = new Date().toISOString()
+): WorkflowRunProjection {
+    const temporalStatus = description.status.name;
+    const terminal = isTerminalTemporalStatus(temporalStatus);
+
+    return {
+        namespace: entry.namespace,
+        workflowId: entry.workflowId,
+        runId: entry.runId,
+        taskQueue: entry.taskQueue,
+        workflow_id: entry.workflow_id,
+        repositoryRoot: entry.repositoryRoot,
+        mode: entry.mode,
+        recoveryState,
+        lastSyncedAt: syncedAt,
+        terminal,
+        temporalStatus,
+        completedNodeIds: [],
+        skippedNodeIds: [],
+        cancelled: temporalStatus === 'CANCELLED',
+        validationSummaries: [],
+        pendingHumanQuestions: [],
+    };
+}

--- a/src/temporal/workflowRunRecoveryService.ts
+++ b/src/temporal/workflowRunRecoveryService.ts
@@ -77,11 +77,13 @@ export function createWorkflowRunRecoveryContext(
     input: {
         log: (line: string) => void;
         isReady: () => boolean;
+        indexStore?: WorkflowRunIndexStore;
     }
 ): WorkflowRunRecoveryContext {
     const windowId = vscode.env.sessionId;
     const globalStoragePath = extensionContext.globalStorageUri.fsPath;
-    const indexStore = new WorkflowRunIndexStore(globalStoragePath, windowId);
+    const indexStore =
+        input.indexStore ?? new WorkflowRunIndexStore(globalStoragePath, windowId);
 
     return {
         windowId,

--- a/src/temporal/workflowRunRecoveryService.ts
+++ b/src/temporal/workflowRunRecoveryService.ts
@@ -1,0 +1,115 @@
+import * as vscode from 'vscode';
+import { getRegisteredStoredApiKeyReader } from './externalCredentials';
+import { resolveExternalApiKey, resolveExternalSettings } from './externalSettings';
+import { resolveManagedLocalSettings } from './managedLocalSettings';
+import { resolveTemporalMode } from './temporalSettings';
+import {
+    buildExternalRecoveryConnectionOptions,
+    createTemporalRecoveryClient,
+    runManualRecoveryRefresh,
+    type TemporalRecoveryClient,
+} from './temporalRecoveryScan';
+import { WorkflowRunIndexStore } from './workflowRunIndex';
+
+export interface WorkflowRunRecoveryContext {
+    windowId: string;
+    globalStoragePath: string;
+    log: (line: string) => void;
+    indexStore: WorkflowRunIndexStore;
+    createRecoveryClient: () => Promise<TemporalRecoveryClient>;
+    isReady: () => boolean;
+}
+
+let recoveryContext: WorkflowRunRecoveryContext | undefined;
+const refreshListeners = new Set<() => void>();
+
+export function registerWorkflowRunRecoveryContext(context: WorkflowRunRecoveryContext): void {
+    recoveryContext = context;
+}
+
+export function getWorkflowRunRecoveryContext(): WorkflowRunRecoveryContext | undefined {
+    return recoveryContext;
+}
+
+export function onWorkflowRunIndexChanged(listener: () => void): () => void {
+    refreshListeners.add(listener);
+    return () => {
+        refreshListeners.delete(listener);
+    };
+}
+
+export function notifyWorkflowRunIndexChanged(): void {
+    for (const listener of refreshListeners) {
+        listener();
+    }
+}
+
+export async function createDefaultRecoveryClient(
+    globalStoragePath: string,
+    windowId: string
+): Promise<TemporalRecoveryClient> {
+    const mode = resolveTemporalMode();
+
+    if (mode === 'external') {
+        const settings = resolveExternalSettings();
+        const apiKey = await resolveExternalApiKey(getRegisteredStoredApiKeyReader());
+        return createTemporalRecoveryClient({
+            mode,
+            namespace: settings.namespace ?? 'default',
+            externalConnectionOptions: buildExternalRecoveryConnectionOptions(settings, apiKey),
+        });
+    }
+
+    const settings = resolveManagedLocalSettings({
+        globalStoragePath,
+        windowId,
+    });
+
+    return createTemporalRecoveryClient({
+        mode,
+        namespace: settings.namespace,
+        grpcPort: settings.grpcPort,
+    });
+}
+
+export function createWorkflowRunRecoveryContext(
+    extensionContext: vscode.ExtensionContext,
+    input: {
+        log: (line: string) => void;
+        isReady: () => boolean;
+    }
+): WorkflowRunRecoveryContext {
+    const windowId = vscode.env.sessionId;
+    const globalStoragePath = extensionContext.globalStorageUri.fsPath;
+    const indexStore = new WorkflowRunIndexStore(globalStoragePath, windowId);
+
+    return {
+        windowId,
+        globalStoragePath,
+        log: input.log,
+        indexStore,
+        isReady: input.isReady,
+        createRecoveryClient: () => createDefaultRecoveryClient(globalStoragePath, windowId),
+    };
+}
+
+export async function refreshWorkflowRunsManually(): Promise<void> {
+    const context = recoveryContext;
+    if (!context) {
+        throw new Error('Workflow run recovery is not initialized.');
+    }
+
+    if (!context.isReady()) {
+        throw new Error('Temporal and worker must be ready before refreshing workflow runs.');
+    }
+
+    context.indexStore.reload();
+    await runManualRecoveryRefresh({
+        windowId: context.windowId,
+        globalStoragePath: context.globalStoragePath,
+        indexStore: context.indexStore,
+        log: context.log,
+        createClient: context.createRecoveryClient,
+    });
+    notifyWorkflowRunIndexChanged();
+}

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -53,9 +53,54 @@ export const window = {
         dispose: vi.fn(),
     })),
     createWebviewPanel: vi.fn(),
+    createTreeView: vi.fn(() => ({
+        dispose: vi.fn(),
+    })),
     showQuickPick: vi.fn(),
     showInputBox: vi.fn()
 };
+
+export class TreeItem {
+    label?: string;
+    description?: string;
+    tooltip?: string;
+    contextValue?: string;
+    collapsibleState?: number;
+
+    constructor(label: string, collapsibleState: number) {
+        this.label = label;
+        this.collapsibleState = collapsibleState;
+    }
+}
+
+export const TreeItemCollapsibleState = {
+    None: 0,
+    Collapsed: 1,
+    Expanded: 2,
+};
+
+export class EventEmitter<T> {
+    private listeners = new Set<(value: T) => void>();
+
+    event = (listener: (value: T) => void) => {
+        this.listeners.add(listener);
+        return {
+            dispose: () => {
+                this.listeners.delete(listener);
+            },
+        };
+    };
+
+    fire(value: T): void {
+        for (const listener of this.listeners) {
+            listener(value);
+        }
+    }
+
+    dispose(): void {
+        this.listeners.clear();
+    }
+}
 
 export const commands = {
     registerCommand: vi.fn(),


### PR DESCRIPTION
## Description

Implements Temporal workflow run recovery for parent #21 across sub-issues #43, #44, and #45.

### #43 — Window-scoped run index
- `WorkflowRunIndexStore` with atomic read/write at `{extensionGlobalStorage}/temporal/{windowId}/run-index.json`
- Run start append, terminal updates, completed-run retention (30 days / 100-entry cap), listing API

### #44 — Automatic recovery scan
- Hooks recovery to combined Temporal + worker `ready` (same gate as run creation)
- Runs once per window session on first combined readiness after activation
- Refreshes non-terminal index entries from Temporal describe/history
- Rebuilds cached `WorkflowRunProjection` files (Temporal wins over stale cache)
- Assigns `recoveryState` (`synced`, `orphaned`, `refresh_failed`, `unreachable`) per observability contract
- Logs scan progress with `[forge.temporal.recovery]` prefix (no secrets)

### #45 — Recovery surfaces and basic actions
- **Forge: Refresh workflow runs** manual re-scan of all index entries within retention
- **Forge: Open Workflow Run List** TreeView with per-run recovery badges and **Needs input** when applicable
- Cancel (Temporal terminate + confirm), dismiss orphaned (index-only removal), and human-input entry points
- Actions blocked during `recovery_pending`, `refresh_failed`, and `unreachable` with contract copy
- Recovery summary logged to Forge Temporal output channel

Closes #43
Closes #44
Closes #45
Part of #21

## Motivation and Context

Forge needs durable local pointers to Temporal executions, automatic projection refresh after extension restart, and operator-facing recovery controls so run state is trustworthy before cancel, dismiss, or human-input actions.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

Recovery tests cover state transitions, once-per-session scan guard, stale projection overwrite, orphaned detection, manual refresh scope, cancel/dismiss guards, and human-answer update routing.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)