### PR TITLE
Execute workflow agent activities through the Cursor SDK boundary (#22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.28.0",
       "license": "MIT",
       "dependencies": {
+        "@cursor/sdk": "^1.0.18",
         "@octokit/rest": "^22.0.1",
         "@temporalio/client": "^1.17.2",
         "@temporalio/worker": "^1.17.2",
@@ -616,6 +617,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -625,6 +632,147 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.18.tgz",
+      "integrity": "sha512-ha5EGHliMuTNuAqnPHzKFNnND4y6erddTqtxwIt9/p8ER+QsmMoRcP38PwA2sXfZnGvIBiozveBZqa4XwUddCw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "sqlite3": "^5.1.7",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.18",
+        "@cursor/sdk-darwin-x64": "1.0.18",
+        "@cursor/sdk-linux-arm64": "1.0.18",
+        "@cursor/sdk-linux-x64": "1.0.18",
+        "@cursor/sdk-win32-x64": "1.0.18"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.18.tgz",
+      "integrity": "sha512-gXfNz+n3uf2hWCUcSdU/gBYT7TFlWwJjZAAjXFzBJ3jGu+l7ShQRa9QI2sEKvPNRtUMC/18EcQ26ks1o261Bnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.18.tgz",
+      "integrity": "sha512-nzcPqCvPPnYsuz21olPgandVgGUzDZkHN4cUls4ukm7mddp6XqujFJv8lh9qKmVefl0/3UL2R6GFANggjwifnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.18.tgz",
+      "integrity": "sha512-MJyhVryN+0czP48SgMak/KA9xGneQ/gdsnDk1ZTJF+LemaFc+Tv7P1GT80h+3JBfu69kPyIX4epJVjroTMoFEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.18.tgz",
+      "integrity": "sha512-IaJqcKtXxtQEdPxivQjDWbvynw3UX31V8RdagcZ6RgHOo+B/i/P95D8svSNC4V9nbTHwVbNGfIDQ5S64gMS2hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.18.tgz",
+      "integrity": "sha512-iqcGt1l/3xgnaT+PotY3237oyK3VnOZHtjUxSRP3Q7ahjaqsZVTnCwwljj+nal8ouvXidBHnxQLqGMSC2G6LTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -1139,6 +1287,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
@@ -1167,6 +1324,13 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
     },
@@ -1824,6 +1988,32 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -3241,6 +3431,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.15.40",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
@@ -4355,6 +4560,16 @@
         "url": "https://github.com/sponsors/ueberdosis"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -5371,6 +5586,13 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5427,11 +5649,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -5532,6 +5767,43 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5649,14 +5921,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5671,8 +5942,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.5",
@@ -5705,13 +5975,20 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -5722,9 +5999,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5815,7 +6090,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5831,7 +6105,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5875,6 +6148,141 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cacache/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacache/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacache/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -6041,9 +6449,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -6058,7 +6464,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6284,6 +6690,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -6329,7 +6745,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -6386,6 +6802,13 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/conventional-changelog-angular": {
       "version": "8.1.0",
@@ -6647,7 +7070,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6665,9 +7088,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -6722,7 +7143,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -6824,6 +7244,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6838,9 +7265,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7028,6 +7453,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -7046,9 +7481,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -7228,7 +7661,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7259,6 +7692,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -7697,9 +8137,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
       "license": "(MIT OR WTFPL)",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -7884,6 +8322,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8041,9 +8485,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.2",
@@ -8060,6 +8502,36 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/fs-monkey": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
@@ -8070,7 +8542,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -8119,6 +8591,47 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/gensync": {
@@ -8228,9 +8741,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "11.1.0",
@@ -8551,6 +9062,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -8662,6 +9180,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -8700,6 +9225,16 @@
         "node": ">=18.18.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -8725,7 +9260,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8740,8 +9274,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8819,7 +9352,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -8829,7 +9362,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8848,12 +9381,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -8864,14 +9404,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -8914,6 +9452,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-arguments": {
@@ -9112,6 +9660,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -9365,7 +9920,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -9934,6 +10489,109 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -10105,9 +10763,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -10145,7 +10801,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10161,13 +10816,224 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -10183,7 +11049,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -10228,9 +11094,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10238,6 +11102,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -10265,9 +11139,7 @@
       "version": "3.85.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
       "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -10299,6 +11171,77 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/node-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -10317,6 +11260,22 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/normalize-package-data": {
@@ -12316,6 +13275,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -12415,7 +13391,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -12765,7 +13740,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13077,9 +14052,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -13161,6 +14134,27 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
@@ -13422,9 +14416,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -13491,7 +14483,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -13520,7 +14511,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13807,6 +14797,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -13823,7 +14823,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -13839,7 +14839,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -13851,7 +14851,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -13872,7 +14872,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13983,7 +14983,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14581,7 +15580,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14619,6 +15617,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -14909,7 +15914,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14924,14 +15928,12 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14947,7 +15949,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -15008,6 +16009,60 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/source-map": {
@@ -15123,6 +16178,69 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sqlite3/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ssri/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -15166,7 +16284,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -15176,7 +16293,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -15475,13 +16591,29 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -15493,9 +16625,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -15511,9 +16641,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15522,6 +16650,30 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/temp-dir": {
       "version": "3.0.0",
@@ -15952,9 +17104,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -16099,6 +17249,26 @@
         "fs-monkey": "^1.0.0"
       }
     },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "node_modules/unique-string": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -16195,7 +17365,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -17110,7 +18279,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -17198,6 +18367,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/wildcard": {
@@ -17316,7 +18495,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/wsl-utils": {
@@ -17472,6 +18650,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -319,6 +319,7 @@
     }
   },
   "dependencies": {
+    "@cursor/sdk": "^1.0.18",
     "@octokit/rest": "^22.0.1",
     "@temporalio/client": "^1.17.2",
     "@temporalio/worker": "^1.17.2",

--- a/resources/workflow/worker/start-worker.js
+++ b/resources/workflow/worker/start-worker.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const path = require('path');
 const { NativeConnection, Worker } = require('@temporalio/worker');
+const { createWorkerActivities } = require(path.join(__dirname, '../../../dist/worker.js'));
 
 function resolveSetting(envKey, fallback) {
     const value = process.env[envKey];
@@ -84,7 +86,7 @@ async function main() {
         connection,
         namespace,
         taskQueue,
-        activities: {},
+        activities: createWorkerActivities(),
     });
 
     process.stdout.write(`FORGE_WORKER_READY:taskQueue=${taskQueue}\n`);

--- a/scripts/verify-packaging.sh
+++ b/scripts/verify-packaging.sh
@@ -25,7 +25,6 @@ require('@temporalio/worker');
 require.resolve('@temporalio/worker/package.json');
 require.resolve('@temporalio/core-bridge');
 require('@cursor/sdk');
-require.resolve('@cursor/sdk/package.json');
 console.log('dependency closure ok for', devServer, 'and', worker);
 "
 

--- a/scripts/verify-packaging.sh
+++ b/scripts/verify-packaging.sh
@@ -24,6 +24,8 @@ const worker = path.join(process.cwd(), '$WORKER_ENTRY');
 require('@temporalio/worker');
 require.resolve('@temporalio/worker/package.json');
 require.resolve('@temporalio/core-bridge');
+require('@cursor/sdk');
+require.resolve('@cursor/sdk/package.json');
 console.log('dependency closure ok for', devServer, 'and', worker);
 "
 
@@ -52,6 +54,11 @@ grep -Fxq "extension/$DEV_SERVER_ENTRY" <<< "$VSIX_LISTING" || {
 
 grep -Fxq "extension/$WORKER_ENTRY" <<< "$VSIX_LISTING" || {
     echo "verify-packaging: worker entry missing from VSIX" >&2
+    exit 1
+}
+
+grep -Fxq "extension/dist/worker.js" <<< "$VSIX_LISTING" || {
+    echo "verify-packaging: worker bundle missing from VSIX" >&2
     exit 1
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,11 @@ import {
     registerStoredApiKeyReader,
 } from './temporal/externalCredentials';
 import {
+    clearRegisteredStoredCursorApiKeyReader,
+    createStoredCursorApiKeyReader,
+    registerStoredCursorApiKeyReader,
+} from './temporal/cursorCredentials';
+import {
     registerTemporalLocalSupervisor,
     shutdownTemporalLocalSupervisor,
 } from './temporal';
@@ -190,6 +195,13 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push({
         dispose: () => {
             clearRegisteredStoredApiKeyReader();
+        },
+    });
+
+    registerStoredCursorApiKeyReader(createStoredCursorApiKeyReader(context.secrets));
+    context.subscriptions.push({
+        dispose: () => {
+            clearRegisteredStoredCursorApiKeyReader();
         },
     });
 

--- a/src/temporal/TemporalWorkerSupervisor.ts
+++ b/src/temporal/TemporalWorkerSupervisor.ts
@@ -222,7 +222,10 @@ export class TemporalWorkerSupervisor {
 
         const connection = await this.resolveConnection();
         const entryPath = resolveWorkerEntry(this.config.extensionPath);
-        const env = buildWorkerSpawnEnv(this.config, connection);
+        const cursorApiKey = this.config.resolveCursorApiKey
+            ? await this.config.resolveCursorApiKey()
+            : undefined;
+        const env = buildWorkerSpawnEnv(this.config, connection, { cursorApiKey });
 
         this.log(
             `[forge.temporal.worker] starting windowId=${this.config.windowId} mode=${this.config.mode} taskQueue=${connection.taskQueue} namespace=${connection.namespace} extensionVersion=${this.config.extensionVersion}`

--- a/src/temporal/cursorCredentials.test.ts
+++ b/src/temporal/cursorCredentials.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveCursorApiKeyForWorker } from './cursorCredentials';
+
+describe('resolveCursorApiKeyForWorker', () => {
+    it('prefers CURSOR_API_KEY env override over SecretStorage reader', async () => {
+        process.env.CURSOR_API_KEY = 'env-key';
+        const reader = vi.fn(async () => 'stored-key');
+
+        await expect(resolveCursorApiKeyForWorker(reader)).resolves.toBe('env-key');
+
+        delete process.env.CURSOR_API_KEY;
+    });
+
+    it('falls back to SecretStorage reader when env is unset', async () => {
+        delete process.env.CURSOR_API_KEY;
+        const reader = vi.fn(async () => 'stored-key');
+
+        await expect(resolveCursorApiKeyForWorker(reader)).resolves.toBe('stored-key');
+    });
+});

--- a/src/temporal/cursorCredentials.ts
+++ b/src/temporal/cursorCredentials.ts
@@ -1,0 +1,43 @@
+import type * as vscode from 'vscode';
+
+export const CURSOR_API_KEY_SECRET_KEY = 'forge.cursor.apiKey';
+
+export type StoredCursorApiKeyReader = () => Promise<string | undefined>;
+
+export function createStoredCursorApiKeyReader(
+    secrets: vscode.SecretStorage
+): StoredCursorApiKeyReader {
+    return async () => {
+        const stored = await secrets.get(CURSOR_API_KEY_SECRET_KEY);
+        return stored?.trim() || undefined;
+    };
+}
+
+let registeredStoredCursorApiKeyReader: StoredCursorApiKeyReader | undefined;
+
+export function registerStoredCursorApiKeyReader(reader: StoredCursorApiKeyReader): void {
+    registeredStoredCursorApiKeyReader = reader;
+}
+
+export function getRegisteredStoredCursorApiKeyReader(): StoredCursorApiKeyReader | undefined {
+    return registeredStoredCursorApiKeyReader;
+}
+
+export function clearRegisteredStoredCursorApiKeyReader(): void {
+    registeredStoredCursorApiKeyReader = undefined;
+}
+
+export async function resolveCursorApiKeyForWorker(
+    reader?: StoredCursorApiKeyReader
+): Promise<string | undefined> {
+    const envKey = process.env.CURSOR_API_KEY?.trim();
+    if (envKey) {
+        return envKey;
+    }
+
+    if (!reader) {
+        return undefined;
+    }
+
+    return reader();
+}

--- a/src/temporal/temporalWindowRegistry.ts
+++ b/src/temporal/temporalWindowRegistry.ts
@@ -5,6 +5,10 @@ import {
 import { TemporalLocalSupervisor } from './TemporalLocalSupervisor';
 import { TemporalWorkerSupervisor } from './TemporalWorkerSupervisor';
 import { getRegisteredStoredApiKeyReader } from './externalCredentials';
+import {
+    getRegisteredStoredCursorApiKeyReader,
+    resolveCursorApiKeyForWorker,
+} from './cursorCredentials';
 import { resolveExternalApiKey, resolveExternalSettings } from './externalSettings';
 import {
     ensurePersistenceDirectory,
@@ -82,6 +86,8 @@ function registerWorkerSupervisor(
             mode === 'external'
                 ? () => resolveExternalApiKey(getRegisteredStoredApiKeyReader())
                 : undefined,
+        resolveCursorApiKey: () =>
+            resolveCursorApiKeyForWorker(getRegisteredStoredCursorApiKeyReader()),
         isTemporalConnectionReady,
     };
 

--- a/src/temporal/types.ts
+++ b/src/temporal/types.ts
@@ -76,6 +76,7 @@ export interface TemporalWorkerSupervisorConfig {
     grpcPort?: number;
     resolveExternalSettings?: () => import('./externalSettings').ResolvedExternalSettings;
     resolveApiKey?: () => Promise<string | undefined>;
+    resolveCursorApiKey?: () => Promise<string | undefined>;
     isTemporalConnectionReady: () => boolean;
 }
 

--- a/src/temporal/workerLaunch.test.ts
+++ b/src/temporal/workerLaunch.test.ts
@@ -85,4 +85,18 @@ describe('buildWorkerSpawnEnv', () => {
 
         expect(env.FORGE_TEMPORAL_EXTERNAL_API_KEY).toBeUndefined();
     });
+
+    it('injects Cursor API key into worker env when provided at spawn', () => {
+        const connection = resolveManagedLocalWorkerConnection({
+            grpcPort: 7233,
+            namespace: 'forge-local',
+            taskQueue: 'forge-workflows',
+        });
+
+        const env = buildWorkerSpawnEnv(baseConfig, connection, {
+            cursorApiKey: 'cursor-secret-key',
+        });
+
+        expect(env.CURSOR_API_KEY).toBe('cursor-secret-key');
+    });
 });

--- a/src/temporal/workerLaunch.ts
+++ b/src/temporal/workerLaunch.ts
@@ -35,7 +35,8 @@ export function buildWorkerSpawnEnv(
         taskQueue: string;
         externalSettings?: ResolvedExternalSettings;
         apiKey?: string;
-    }
+    },
+    options: { cursorApiKey?: string } = {}
 ): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = {
         ...process.env,
@@ -64,6 +65,11 @@ export function buildWorkerSpawnEnv(
         if (connection.apiKey) {
             env.FORGE_TEMPORAL_EXTERNAL_API_KEY = connection.apiKey;
         }
+    }
+
+    const cursorApiKey = options.cursorApiKey?.trim() || process.env.CURSOR_API_KEY?.trim();
+    if (cursorApiKey) {
+        env.CURSOR_API_KEY = cursorApiKey;
     }
 
     return env;

--- a/src/worker/activityEnvelope.ts
+++ b/src/worker/activityEnvelope.ts
@@ -1,0 +1,51 @@
+export const ACTIVITY_ENVELOPE_VERSION = '1.0.0';
+
+export type ActivityOutputType = 'json' | 'markdown' | 'text';
+
+export type ActivityFailureClass = 'startup' | 'execution' | 'cancelled';
+
+export type ActivityStatus = 'finished' | 'error' | 'cancelled';
+
+export interface ActivityDiagnostic {
+    code: string;
+    message: string;
+    severity: 'error' | 'warning' | 'info';
+    path?: string;
+    source?: 'sdk' | 'worker' | 'validator';
+}
+
+export interface CursorSdkRequestEnvelope {
+    envelope_version: string;
+    activity_id: string;
+    node_id: string;
+    workflow_run_id: string;
+    agent_path?: string;
+    skill_path?: string;
+    prompt: string;
+    inputs: Record<string, unknown>;
+    model?: string;
+    artifact_ids?: string[];
+    output_type: ActivityOutputType;
+}
+
+export interface CursorSdkResponseEnvelope {
+    envelope_version: string;
+    activity_id: string;
+    node_id: string;
+    workflow_run_id: string;
+    cursor_agent_id: string;
+    cursor_run_id: string;
+    agent_path?: string;
+    skill_path?: string;
+    output_type: ActivityOutputType;
+    status: ActivityStatus;
+    failure_class?: ActivityFailureClass;
+    retryable: boolean;
+    structured_payload?: unknown;
+    diagnostics?: ActivityDiagnostic[];
+}
+
+export interface ExecuteCursorSdkAgentActivityInput {
+    envelope: CursorSdkRequestEnvelope;
+    workspaceRoot: string;
+}

--- a/src/worker/composeSdkPrompt.test.ts
+++ b/src/worker/composeSdkPrompt.test.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { composeSdkPrompt } from './composeSdkPrompt';
+import type { CursorSdkRequestEnvelope } from './activityEnvelope';
+
+describe('composeSdkPrompt', () => {
+    const tempDirs: string[] = [];
+
+    afterEach(() => {
+        for (const dir of tempDirs) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+        tempDirs.length = 0;
+    });
+
+    it('combines binding content, prompt, and inputs', () => {
+        const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-compose-'));
+        tempDirs.push(workspaceRoot);
+        const agentPath = '.cursor/agents/engineer.md';
+        fs.mkdirSync(path.join(workspaceRoot, '.cursor/agents'), { recursive: true });
+        fs.writeFileSync(path.join(workspaceRoot, agentPath), '# Engineer\nBuild the issue.');
+
+        const envelope: CursorSdkRequestEnvelope = {
+            envelope_version: '1.0.0',
+            activity_id: 'forge.engineer.build',
+            node_id: 'build-node',
+            workflow_run_id: 'run-1',
+            agent_path: agentPath,
+            prompt: 'Implement issue #46.',
+            inputs: { issueNumber: 46 },
+            output_type: 'markdown',
+        };
+
+        const prompt = composeSdkPrompt(envelope, workspaceRoot);
+
+        expect(prompt).toContain('## Agent binding');
+        expect(prompt).toContain(agentPath);
+        expect(prompt).toContain('# Engineer');
+        expect(prompt).toContain('Implement issue #46.');
+        expect(prompt).toContain('"issueNumber": 46');
+    });
+});

--- a/src/worker/composeSdkPrompt.ts
+++ b/src/worker/composeSdkPrompt.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import type { CursorSdkRequestEnvelope } from './activityEnvelope';
+
+function readBindingContent(
+    workspaceRoot: string,
+    bindingPath: string | undefined
+): string | undefined {
+    if (!bindingPath) {
+        return undefined;
+    }
+
+    const absolutePath = path.resolve(workspaceRoot, bindingPath);
+    if (!fs.existsSync(absolutePath)) {
+        return undefined;
+    }
+
+    return fs.readFileSync(absolutePath, 'utf8');
+}
+
+export function composeSdkPrompt(
+    envelope: CursorSdkRequestEnvelope,
+    workspaceRoot: string
+): string {
+    const sections: string[] = [];
+
+    const bindingPath = envelope.agent_path ?? envelope.skill_path;
+    const bindingLabel = envelope.agent_path ? 'Agent' : 'Skill';
+    const bindingContent = readBindingContent(workspaceRoot, bindingPath);
+
+    if (bindingPath) {
+        sections.push(`## ${bindingLabel} binding`);
+        sections.push(`Path: ${bindingPath}`);
+        if (bindingContent) {
+            sections.push(bindingContent);
+        }
+    }
+
+    sections.push('## Task');
+    sections.push(envelope.prompt.trim());
+
+    if (Object.keys(envelope.inputs).length > 0) {
+        sections.push('## Inputs');
+        sections.push(JSON.stringify(envelope.inputs, null, 2));
+    }
+
+    return sections.join('\n\n');
+}

--- a/src/worker/cursorActivityLog.ts
+++ b/src/worker/cursorActivityLog.ts
@@ -1,0 +1,74 @@
+import type { CursorSdkResponseEnvelope } from './activityEnvelope';
+
+const LOG_PREFIX = '[forge.activity.cursor]';
+
+export interface CursorActivityLogFields {
+    activity_id: string;
+    node_id: string;
+    cursor_agent_id?: string;
+    cursor_run_id?: string;
+    status?: string;
+    failure_class?: string;
+    retryable?: boolean;
+    artifact_ref_paths?: string[];
+    event?: string;
+}
+
+function formatLogLine(fields: CursorActivityLogFields): string {
+    const parts = [
+        `${LOG_PREFIX} activity_id=${fields.activity_id}`,
+        `node_id=${fields.node_id}`,
+    ];
+
+    if (fields.cursor_agent_id) {
+        parts.push(`cursor_agent_id=${fields.cursor_agent_id}`);
+    }
+    if (fields.cursor_run_id) {
+        parts.push(`cursor_run_id=${fields.cursor_run_id}`);
+    }
+    if (fields.status) {
+        parts.push(`status=${fields.status}`);
+    }
+    if (fields.failure_class) {
+        parts.push(`failure_class=${fields.failure_class}`);
+    }
+    if (fields.retryable !== undefined) {
+        parts.push(`retryable=${String(fields.retryable)}`);
+    }
+    if (fields.artifact_ref_paths && fields.artifact_ref_paths.length > 0) {
+        parts.push(`artifact_refs=${fields.artifact_ref_paths.join(',')}`);
+    }
+    if (fields.event) {
+        parts.push(`event=${fields.event}`);
+    }
+
+    return parts.join(' ');
+}
+
+export type CursorActivityLogger = (line: string) => void;
+
+export function createCursorActivityLogger(
+    log: CursorActivityLogger = (line) => process.stderr.write(`${line}\n`)
+): {
+    logMetadata: (fields: CursorActivityLogFields) => void;
+    logResponseEnvelope: (envelope: CursorSdkResponseEnvelope) => void;
+} {
+    return {
+        logMetadata(fields: CursorActivityLogFields) {
+            log(formatLogLine(fields));
+        },
+        logResponseEnvelope(envelope: CursorSdkResponseEnvelope) {
+            log(
+                formatLogLine({
+                    activity_id: envelope.activity_id,
+                    node_id: envelope.node_id,
+                    cursor_agent_id: envelope.cursor_agent_id,
+                    cursor_run_id: envelope.cursor_run_id,
+                    status: envelope.status,
+                    failure_class: envelope.failure_class,
+                    retryable: envelope.retryable,
+                })
+            );
+        },
+    };
+}

--- a/src/worker/disposeSdkAgent.ts
+++ b/src/worker/disposeSdkAgent.ts
@@ -1,0 +1,14 @@
+import type { SDKAgent } from '@cursor/sdk';
+
+export async function disposeSdkAgent(agent: SDKAgent | undefined): Promise<void> {
+    if (!agent) {
+        return;
+    }
+
+    if (typeof agent[Symbol.asyncDispose] === 'function') {
+        await agent[Symbol.asyncDispose]();
+        return;
+    }
+
+    agent.close();
+}

--- a/src/worker/executeCursorSdkAgentActivity.test.ts
+++ b/src/worker/executeCursorSdkAgentActivity.test.ts
@@ -1,0 +1,150 @@
+import { CursorAgentError } from '@cursor/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CursorSdkRequestEnvelope } from './activityEnvelope';
+import { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
+
+const heartbeatMock = vi.fn();
+const cancellationController = new AbortController();
+
+vi.mock('@temporalio/activity', () => ({
+    heartbeat: (...args: unknown[]) => heartbeatMock(...args),
+    Context: {
+        current: () => ({
+            cancellationSignal: cancellationController.signal,
+        }),
+    },
+}));
+
+describe('executeCursorSdkAgentActivity', () => {
+    const envelope: CursorSdkRequestEnvelope = {
+        envelope_version: '1.0.0',
+        activity_id: 'forge.test.activity',
+        node_id: 'node-1',
+        workflow_run_id: 'run-1',
+        agent_path: '.cursor/agents/engineer.md',
+        prompt: 'Implement issue #46.',
+        inputs: { issueNumber: 46 },
+        output_type: 'markdown',
+    };
+
+    beforeEach(() => {
+        heartbeatMock.mockReset();
+        delete process.env.CURSOR_API_KEY;
+    });
+
+    it('returns startup failure envelope when API key is missing', async () => {
+        const response = await executeCursorSdkAgentActivity(
+            {
+                envelope,
+                workspaceRoot: '/tmp/workspace',
+            },
+            { log: () => undefined }
+        );
+
+        expect(response.status).toBe('error');
+        expect(response.failure_class).toBe('startup');
+        expect(response.diagnostics?.[0]?.code).toBe('cursor_api_key_missing');
+    });
+
+    it('returns finished envelope on successful SDK run', async () => {
+        process.env.CURSOR_API_KEY = 'cursor_test_key';
+
+        const createAgent = vi.fn(async () => ({
+            agentId: 'agent-123',
+            send: vi.fn(async () => ({
+                id: 'run-456',
+                supports: () => true,
+                wait: vi.fn(async () => ({
+                    id: 'run-456',
+                    status: 'finished',
+                    result: '# Done',
+                })),
+            })),
+            close: vi.fn(),
+            [Symbol.asyncDispose]: vi.fn(async () => undefined),
+        }));
+
+        const response = await executeCursorSdkAgentActivity(
+            {
+                envelope,
+                workspaceRoot: '/tmp/workspace',
+            },
+            {
+                createAgent,
+                log: () => undefined,
+            }
+        );
+
+        expect(createAgent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                apiKey: 'cursor_test_key',
+                local: {
+                    cwd: '/tmp/workspace',
+                    settingSources: [],
+                },
+            })
+        );
+        expect(response.status).toBe('finished');
+        expect(response.cursor_agent_id).toBe('agent-123');
+        expect(response.cursor_run_id).toBe('run-456');
+        expect(response.structured_payload).toBe('# Done');
+        expect(heartbeatMock).toHaveBeenCalledWith({ cursor_run_id: 'run-456' });
+    });
+
+    it('maps CursorAgentError to startup failure envelope', async () => {
+        process.env.CURSOR_API_KEY = 'cursor_test_key';
+
+        const createAgent = vi.fn(async () => {
+            throw new CursorAgentError('auth failed', { isRetryable: true });
+        });
+
+        const response = await executeCursorSdkAgentActivity(
+            {
+                envelope,
+                workspaceRoot: '/tmp/workspace',
+            },
+            {
+                createAgent,
+                log: () => undefined,
+            }
+        );
+
+        expect(response.status).toBe('error');
+        expect(response.failure_class).toBe('startup');
+        expect(response.retryable).toBe(true);
+        expect(response.diagnostics?.[0]?.message).toBe('auth failed');
+    });
+
+    it('returns cancelled envelope when SDK run is cancelled', async () => {
+        process.env.CURSOR_API_KEY = 'cursor_test_key';
+
+        const createAgent = vi.fn(async () => ({
+            agentId: 'agent-123',
+            send: vi.fn(async () => ({
+                id: 'run-456',
+                supports: () => true,
+                wait: vi.fn(async () => ({
+                    id: 'run-456',
+                    status: 'cancelled',
+                })),
+            })),
+            close: vi.fn(),
+            [Symbol.asyncDispose]: vi.fn(async () => undefined),
+        }));
+
+        const response = await executeCursorSdkAgentActivity(
+            {
+                envelope,
+                workspaceRoot: '/tmp/workspace',
+            },
+            {
+                createAgent,
+                log: () => undefined,
+            }
+        );
+
+        expect(response.status).toBe('cancelled');
+        expect(response.failure_class).toBe('cancelled');
+        expect(response.retryable).toBe(false);
+    });
+});

--- a/src/worker/executeCursorSdkAgentActivity.ts
+++ b/src/worker/executeCursorSdkAgentActivity.ts
@@ -1,0 +1,164 @@
+import { Agent, CursorAgentError, type Run, type RunResult } from '@cursor/sdk';
+import { Context, heartbeat } from '@temporalio/activity';
+import path from 'path';
+import type {
+    CursorSdkResponseEnvelope,
+    ExecuteCursorSdkAgentActivityInput,
+} from './activityEnvelope';
+import { composeSdkPrompt } from './composeSdkPrompt';
+import { createCursorActivityLogger, type CursorActivityLogger } from './cursorActivityLog';
+import { disposeSdkAgent } from './disposeSdkAgent';
+import {
+    buildCancelledResponse,
+    buildExecutionFailureResponse,
+    buildMissingApiKeyResponse,
+    buildResponseShell,
+    buildStartupFailureResponse,
+    buildSuccessResponse,
+} from './mapSdkOutcome';
+import { resolveCursorApiKeyFromEnv } from './resolveCursorApiKey';
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+export interface ExecuteCursorSdkAgentActivityDeps {
+    createAgent?: typeof Agent.create;
+    log?: CursorActivityLogger;
+}
+
+async function waitForRunCompletion(
+    run: Run,
+    cancellationSignal: AbortSignal
+): Promise<{ result: RunResult; cancelled: boolean; lateCompletionDiscarded: boolean }> {
+    let cancelled = false;
+    let lateCompletionDiscarded = false;
+
+    const onAbort = () => {
+        cancelled = true;
+        if (run.supports('cancel')) {
+            void run.cancel().catch(() => undefined);
+        }
+    };
+
+    if (cancellationSignal.aborted) {
+        onAbort();
+    } else {
+        cancellationSignal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    const heartbeatTimer = setInterval(() => {
+        heartbeat({ cursor_run_id: run.id });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    try {
+        heartbeat({ cursor_run_id: run.id });
+
+        const result = await run.wait();
+
+        if (cancelled) {
+            lateCompletionDiscarded = true;
+            return {
+                result,
+                cancelled: true,
+                lateCompletionDiscarded,
+            };
+        }
+
+        if (result.status === 'cancelled') {
+            return {
+                result,
+                cancelled: true,
+                lateCompletionDiscarded: false,
+            };
+        }
+
+        return {
+            result,
+            cancelled: false,
+            lateCompletionDiscarded: false,
+        };
+    } finally {
+        clearInterval(heartbeatTimer);
+        cancellationSignal.removeEventListener('abort', onAbort);
+    }
+}
+
+export async function executeCursorSdkAgentActivity(
+    input: ExecuteCursorSdkAgentActivityInput,
+    deps: ExecuteCursorSdkAgentActivityDeps = {}
+): Promise<CursorSdkResponseEnvelope> {
+    const createAgent = deps.createAgent ?? Agent.create;
+    const activityLogger = createCursorActivityLogger(deps.log);
+    const { envelope } = input;
+    const workspaceRoot = path.resolve(input.workspaceRoot);
+
+    const apiKey = resolveCursorApiKeyFromEnv();
+    if (!apiKey) {
+        const response = buildMissingApiKeyResponse(envelope);
+        activityLogger.logResponseEnvelope(response);
+        return response;
+    }
+
+    const prompt = composeSdkPrompt(envelope, workspaceRoot);
+    const model = envelope.model ? { id: envelope.model } : { id: 'composer-2.5' };
+
+    let agent: Awaited<ReturnType<typeof Agent.create>> | undefined;
+
+    try {
+        agent = await createAgent({
+            apiKey,
+            model,
+            local: {
+                cwd: workspaceRoot,
+                settingSources: [],
+            },
+        });
+
+        const run = await agent.send(prompt);
+        const shell = buildResponseShell(envelope, agent.agentId, run.id);
+
+        const { result, cancelled, lateCompletionDiscarded } = await waitForRunCompletion(
+            run,
+            Context.current().cancellationSignal
+        );
+
+        if (lateCompletionDiscarded) {
+            activityLogger.logMetadata({
+                activity_id: envelope.activity_id,
+                node_id: envelope.node_id,
+                cursor_agent_id: agent.agentId,
+                cursor_run_id: run.id,
+                event: 'late_completion_discarded',
+            });
+        }
+
+        if (cancelled || result.status === 'cancelled') {
+            const response = buildCancelledResponse(shell);
+            activityLogger.logResponseEnvelope(response);
+            return response;
+        }
+
+        if (result.status === 'error') {
+            const response = buildExecutionFailureResponse(shell, result, false);
+            activityLogger.logResponseEnvelope(response);
+            return response;
+        }
+
+        const response = buildSuccessResponse(shell, result, envelope.output_type);
+        activityLogger.logResponseEnvelope(response);
+        return response;
+    } catch (error) {
+        if (error instanceof CursorAgentError) {
+            const response = buildStartupFailureResponse(
+                buildResponseShell(envelope, agent?.agentId ?? 'unavailable', 'unavailable'),
+                error.message,
+                error.isRetryable
+            );
+            activityLogger.logResponseEnvelope(response);
+            return response;
+        }
+
+        throw error;
+    } finally {
+        await disposeSdkAgent(agent);
+    }
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,12 +1,32 @@
+import type { ActivityNodePolicyRefs } from '../workflows/activityPolicyRegistry';
+import type { ExecuteCursorSdkAgentActivityInput } from './activityEnvelope';
 import { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
+import { mapEnvelopeToActivityFailure } from './mapEnvelopeToActivityFailure';
+
+export interface RegisteredCursorSdkAgentActivityInput extends ExecuteCursorSdkAgentActivityInput {
+    policyRefs?: ActivityNodePolicyRefs;
+}
+
+async function executeRegisteredCursorSdkAgentActivity(
+    input: RegisteredCursorSdkAgentActivityInput
+): Promise<ReturnType<typeof executeCursorSdkAgentActivity>> {
+    const response = await executeCursorSdkAgentActivity(input);
+    const failure = mapEnvelopeToActivityFailure(response, input.policyRefs);
+    if (failure) {
+        throw failure;
+    }
+    return response;
+}
 
 export function createWorkerActivities() {
     return {
-        executeCursorSdkAgentActivity,
+        executeCursorSdkAgentActivity: executeRegisteredCursorSdkAgentActivity,
     };
 }
 
 export { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
+export { buildTemporalActivityOptions } from './temporalActivityPolicyOptions';
+export { mapEnvelopeToActivityFailure } from './mapEnvelopeToActivityFailure';
 export type {
     CursorSdkRequestEnvelope,
     CursorSdkResponseEnvelope,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,0 +1,14 @@
+import { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
+
+export function createWorkerActivities() {
+    return {
+        executeCursorSdkAgentActivity,
+    };
+}
+
+export { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
+export type {
+    CursorSdkRequestEnvelope,
+    CursorSdkResponseEnvelope,
+    ExecuteCursorSdkAgentActivityInput,
+} from './activityEnvelope';

--- a/src/worker/mapEnvelopeToActivityFailure.test.ts
+++ b/src/worker/mapEnvelopeToActivityFailure.test.ts
@@ -1,0 +1,104 @@
+import { ApplicationFailure } from '@temporalio/common';
+import { describe, expect, it } from 'vitest';
+import type { CursorSdkResponseEnvelope } from './activityEnvelope';
+import { mapEnvelopeToActivityFailure } from './mapEnvelopeToActivityFailure';
+
+function buildErrorEnvelope(
+    overrides: Partial<CursorSdkResponseEnvelope> = {}
+): CursorSdkResponseEnvelope {
+    return {
+        envelope_version: '1.0.0',
+        activity_id: 'forge.test.activity',
+        node_id: 'node-1',
+        workflow_run_id: 'run-1',
+        cursor_agent_id: 'agent-1',
+        cursor_run_id: 'run-1',
+        output_type: 'markdown',
+        status: 'error',
+        failure_class: 'startup',
+        retryable: true,
+        diagnostics: [{ code: 'cursor_sdk_startup', message: 'startup failed', severity: 'error' }],
+        ...overrides,
+    };
+}
+
+describe('mapEnvelopeToActivityFailure', () => {
+    it('returns undefined for finished responses', () => {
+        const response: CursorSdkResponseEnvelope = {
+            envelope_version: '1.0.0',
+            activity_id: 'forge.test.activity',
+            node_id: 'node-1',
+            workflow_run_id: 'run-1',
+            cursor_agent_id: 'agent-1',
+            cursor_run_id: 'run-1',
+            output_type: 'markdown',
+            status: 'finished',
+            retryable: false,
+        };
+
+        expect(mapEnvelopeToActivityFailure(response)).toBeUndefined();
+    });
+
+    it('maps cancelled responses to non-retryable failures', () => {
+        const failure = mapEnvelopeToActivityFailure(
+            buildErrorEnvelope({
+                status: 'cancelled',
+                failure_class: 'cancelled',
+                retryable: false,
+            })
+        );
+
+        expect(failure).toBeInstanceOf(ApplicationFailure);
+        expect(failure?.nonRetryable).toBe(true);
+        expect(failure?.type).toBe('cursor_sdk_cancelled');
+    });
+
+    it('maps retryable startup failures to retryable ApplicationFailure with default policy', () => {
+        const failure = mapEnvelopeToActivityFailure(buildErrorEnvelope());
+
+        expect(failure).toBeInstanceOf(ApplicationFailure);
+        expect(failure?.nonRetryable).not.toBe(true);
+        expect(failure?.type).toBe('cursor_sdk_startup');
+    });
+
+    it('maps non-retryable failures to non-retryable ApplicationFailure', () => {
+        const failure = mapEnvelopeToActivityFailure(
+            buildErrorEnvelope({
+                retryable: false,
+            })
+        );
+
+        expect(failure?.nonRetryable).toBe(true);
+    });
+
+    it('maps retryable execution failures to non-retryable when agent_startup is selected', () => {
+        const failure = mapEnvelopeToActivityFailure(
+            buildErrorEnvelope({
+                failure_class: 'execution',
+                retryable: true,
+            }),
+            { retry_policy: 'agent_startup' }
+        );
+
+        expect(failure?.nonRetryable).toBe(true);
+        expect(failure?.type).toBe('cursor_sdk_execution');
+    });
+
+    it('maps retryable execution failures to retryable when agent_standard is selected', () => {
+        const failure = mapEnvelopeToActivityFailure(
+            buildErrorEnvelope({
+                failure_class: 'execution',
+                retryable: true,
+            }),
+            { retry_policy: 'agent_standard' }
+        );
+
+        expect(failure?.nonRetryable).not.toBe(true);
+    });
+
+    it('maps retryable startup failures to non-retryable when policy is none', () => {
+        const failure = mapEnvelopeToActivityFailure(buildErrorEnvelope(), { retry_policy: 'none' });
+
+        expect(failure?.nonRetryable).toBe(true);
+    });
+});

--- a/src/worker/mapEnvelopeToActivityFailure.ts
+++ b/src/worker/mapEnvelopeToActivityFailure.ts
@@ -1,0 +1,52 @@
+import { ApplicationFailure } from '@temporalio/common';
+import {
+    resolveRetryPolicyId,
+    shouldRetryActivityResponse,
+    type ActivityNodePolicyRefs,
+} from '../workflows/activityPolicyRegistry';
+import type { CursorSdkResponseEnvelope } from './activityEnvelope';
+
+function failureMessage(response: CursorSdkResponseEnvelope): string {
+    const diagnostic = response.diagnostics?.[0];
+    if (diagnostic?.message) {
+        return diagnostic.message;
+    }
+
+    if (response.failure_class === 'cancelled') {
+        return 'Cursor SDK activity was cancelled.';
+    }
+
+    return `Cursor SDK activity ${response.activity_id} failed with status ${response.status}.`;
+}
+
+function failureType(response: CursorSdkResponseEnvelope): string {
+    if (response.failure_class) {
+        return `cursor_sdk_${response.failure_class}`;
+    }
+
+    return 'cursor_sdk_error';
+}
+
+export function mapEnvelopeToActivityFailure(
+    response: CursorSdkResponseEnvelope,
+    policyRefs: ActivityNodePolicyRefs = {}
+): ApplicationFailure | undefined {
+    if (response.status === 'finished') {
+        return undefined;
+    }
+
+    const retryPolicyId = resolveRetryPolicyId(policyRefs);
+    const message = failureMessage(response);
+    const type = failureType(response);
+    const shouldRetry = shouldRetryActivityResponse(
+        response.failure_class,
+        response.retryable,
+        retryPolicyId
+    );
+
+    if (shouldRetry) {
+        return ApplicationFailure.retryable(message, type, response);
+    }
+
+    return ApplicationFailure.nonRetryable(message, type, response);
+}

--- a/src/worker/mapSdkOutcome.test.ts
+++ b/src/worker/mapSdkOutcome.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { CursorSdkRequestEnvelope } from './activityEnvelope';
+import {
+    buildMissingApiKeyResponse,
+    buildSuccessResponse,
+    parseStructuredPayload,
+} from './mapSdkOutcome';
+
+const baseEnvelope: CursorSdkRequestEnvelope = {
+    envelope_version: '1.0.0',
+    activity_id: 'forge.test.activity',
+    node_id: 'node-1',
+    workflow_run_id: 'run-1',
+    skill_path: '.cursor/skills/test/SKILL.md',
+    prompt: 'Do work',
+    inputs: {},
+    output_type: 'json',
+};
+
+describe('mapSdkOutcome', () => {
+    it('builds startup failure when API key is missing', () => {
+        const response = buildMissingApiKeyResponse(baseEnvelope);
+
+        expect(response.status).toBe('error');
+        expect(response.failure_class).toBe('startup');
+        expect(response.retryable).toBe(false);
+        expect(response.diagnostics?.[0]?.code).toBe('cursor_api_key_missing');
+    });
+
+    it('parses json structured payload', () => {
+        const payload = parseStructuredPayload('json', '{"ok":true}');
+        expect(payload).toEqual({ ok: true });
+    });
+
+    it('returns markdown payload as string', () => {
+        const payload = parseStructuredPayload('markdown', '# Done');
+        expect(payload).toBe('# Done');
+    });
+
+    it('builds finished response with structured payload', () => {
+        const shell = {
+            envelope_version: '1.0.0',
+            activity_id: baseEnvelope.activity_id,
+            node_id: baseEnvelope.node_id,
+            workflow_run_id: baseEnvelope.workflow_run_id,
+            cursor_agent_id: 'agent-1',
+            cursor_run_id: 'run-abc',
+            skill_path: baseEnvelope.skill_path,
+            output_type: baseEnvelope.output_type,
+            status: 'error' as const,
+            retryable: false,
+        };
+
+        const response = buildSuccessResponse(
+            shell,
+            { id: 'run-abc', status: 'finished', result: '{"done":true}' },
+            'json'
+        );
+
+        expect(response.status).toBe('finished');
+        expect(response.structured_payload).toEqual({ done: true });
+        expect(response.failure_class).toBeUndefined();
+    });
+});

--- a/src/worker/mapSdkOutcome.ts
+++ b/src/worker/mapSdkOutcome.ts
@@ -1,0 +1,145 @@
+import type { RunResult } from '@cursor/sdk';
+import {
+    ACTIVITY_ENVELOPE_VERSION,
+    type ActivityOutputType,
+    type CursorSdkRequestEnvelope,
+    type CursorSdkResponseEnvelope,
+} from './activityEnvelope';
+
+export function buildResponseShell(
+    envelope: CursorSdkRequestEnvelope,
+    cursorAgentId: string,
+    cursorRunId: string
+): CursorSdkResponseEnvelope {
+    return {
+        envelope_version: ACTIVITY_ENVELOPE_VERSION,
+        activity_id: envelope.activity_id,
+        node_id: envelope.node_id,
+        workflow_run_id: envelope.workflow_run_id,
+        cursor_agent_id: cursorAgentId,
+        cursor_run_id: cursorRunId,
+        ...(envelope.agent_path ? { agent_path: envelope.agent_path } : {}),
+        ...(envelope.skill_path ? { skill_path: envelope.skill_path } : {}),
+        output_type: envelope.output_type,
+        status: 'error',
+        retryable: false,
+    };
+}
+
+export function buildMissingApiKeyResponse(
+    envelope: CursorSdkRequestEnvelope
+): CursorSdkResponseEnvelope {
+    return {
+        envelope_version: ACTIVITY_ENVELOPE_VERSION,
+        activity_id: envelope.activity_id,
+        node_id: envelope.node_id,
+        workflow_run_id: envelope.workflow_run_id,
+        cursor_agent_id: 'unavailable',
+        cursor_run_id: 'unavailable',
+        ...(envelope.agent_path ? { agent_path: envelope.agent_path } : {}),
+        ...(envelope.skill_path ? { skill_path: envelope.skill_path } : {}),
+        output_type: envelope.output_type,
+        status: 'error',
+        failure_class: 'startup',
+        retryable: false,
+        diagnostics: [
+            {
+                code: 'cursor_api_key_missing',
+                message: 'Cursor API key is not configured.',
+                severity: 'error',
+                source: 'worker',
+            },
+        ],
+    };
+}
+
+export function buildStartupFailureResponse(
+    shell: CursorSdkResponseEnvelope,
+    message: string,
+    retryable: boolean
+): CursorSdkResponseEnvelope {
+    return {
+        ...shell,
+        status: 'error',
+        failure_class: 'startup',
+        retryable,
+        diagnostics: [
+            {
+                code: 'cursor_sdk_startup',
+                message,
+                severity: 'error',
+                source: 'sdk',
+            },
+        ],
+    };
+}
+
+export function buildExecutionFailureResponse(
+    shell: CursorSdkResponseEnvelope,
+    result: RunResult,
+    retryable: boolean
+): CursorSdkResponseEnvelope {
+    return {
+        ...shell,
+        status: 'error',
+        failure_class: 'execution',
+        retryable,
+        diagnostics: [
+            {
+                code: 'cursor_sdk_execution',
+                message: `Cursor SDK run ${result.id} finished with status error.`,
+                severity: 'error',
+                source: 'sdk',
+            },
+        ],
+    };
+}
+
+export function buildCancelledResponse(shell: CursorSdkResponseEnvelope): CursorSdkResponseEnvelope {
+    return {
+        ...shell,
+        status: 'cancelled',
+        failure_class: 'cancelled',
+        retryable: false,
+        diagnostics: [
+            {
+                code: 'cursor_sdk_cancelled',
+                message: 'Cursor SDK activity was cancelled.',
+                severity: 'info',
+                source: 'worker',
+            },
+        ],
+    };
+}
+
+export function parseStructuredPayload(
+    outputType: ActivityOutputType,
+    resultText: string | undefined
+): unknown | undefined {
+    if (resultText === undefined) {
+        return undefined;
+    }
+
+    if (outputType === 'json') {
+        try {
+            return JSON.parse(resultText) as unknown;
+        } catch {
+            return { text: resultText };
+        }
+    }
+
+    return resultText;
+}
+
+export function buildSuccessResponse(
+    shell: CursorSdkResponseEnvelope,
+    result: RunResult,
+    outputType: ActivityOutputType
+): CursorSdkResponseEnvelope {
+    return {
+        ...shell,
+        status: 'finished',
+        retryable: false,
+        structured_payload: parseStructuredPayload(outputType, result.result),
+    };
+}

--- a/src/worker/resolveCursorApiKey.ts
+++ b/src/worker/resolveCursorApiKey.ts
@@ -1,0 +1,4 @@
+export function resolveCursorApiKeyFromEnv(): string | undefined {
+    const value = process.env.CURSOR_API_KEY?.trim();
+    return value && value.length > 0 ? value : undefined;
+}

--- a/src/worker/temporalActivityPolicyOptions.test.ts
+++ b/src/worker/temporalActivityPolicyOptions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildTemporalActivityOptions } from './temporalActivityPolicyOptions';
+
+describe('buildTemporalActivityOptions', () => {
+    it('applies agent_default and agent_standard when node policies are omitted', () => {
+        const options = buildTemporalActivityOptions({});
+
+        expect(options.startToCloseTimeout).toBe(30 * 60 * 1_000);
+        expect(options.scheduleToCloseTimeout).toBe(45 * 60 * 1_000);
+        expect(options.retry).toEqual(
+            expect.objectContaining({
+                maximumAttempts: 3,
+                initialInterval: 1_000,
+                maximumInterval: 30_000,
+                backoffCoefficient: 2,
+                nonRetryableErrorTypes: ['cursor_sdk_cancelled'],
+            })
+        );
+    });
+
+    it('applies explicit node policy references', () => {
+        const options = buildTemporalActivityOptions({
+            retry_policy: 'none',
+            timeout_policy: 'agent_short',
+        });
+
+        expect(options.startToCloseTimeout).toBe(5 * 60 * 1_000);
+        expect(options.scheduleToCloseTimeout).toBe(10 * 60 * 1_000);
+        expect(options.retry?.maximumAttempts).toBe(1);
+    });
+});

--- a/src/worker/temporalActivityPolicyOptions.ts
+++ b/src/worker/temporalActivityPolicyOptions.ts
@@ -1,0 +1,27 @@
+import type { ActivityOptions } from '@temporalio/common';
+import {
+    getRetryPolicyDefinition,
+    getTimeoutPolicyDefinition,
+    resolveRetryPolicyId,
+    resolveTimeoutPolicyId,
+    type ActivityNodePolicyRefs,
+} from '../workflows/activityPolicyRegistry';
+
+export function buildTemporalActivityOptions(policyRefs: ActivityNodePolicyRefs = {}): ActivityOptions {
+    const retryPolicyId = resolveRetryPolicyId(policyRefs);
+    const timeoutPolicyId = resolveTimeoutPolicyId(policyRefs);
+    const retry = getRetryPolicyDefinition(retryPolicyId);
+    const timeout = getTimeoutPolicyDefinition(timeoutPolicyId);
+
+    return {
+        startToCloseTimeout: timeout.startToCloseMs,
+        scheduleToCloseTimeout: timeout.scheduleToCloseMs,
+        retry: {
+            maximumAttempts: retry.maximumAttempts,
+            initialInterval: retry.initialIntervalMs,
+            maximumInterval: retry.maximumIntervalMs,
+            backoffCoefficient: retry.backoffCoefficient,
+            nonRetryableErrorTypes: ['cursor_sdk_cancelled'],
+        },
+    };
+}

--- a/src/workflows/activityPolicyRegistry.test.ts
+++ b/src/workflows/activityPolicyRegistry.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_RETRY_POLICY_ID,
+    DEFAULT_TIMEOUT_POLICY_ID,
+    getRetryPolicyDefinition,
+    getTimeoutPolicyDefinition,
+    isKnownRetryPolicyId,
+    isKnownTimeoutPolicyId,
+    resolveRetryPolicyId,
+    resolveTimeoutPolicyId,
+    shouldRetryActivityResponse,
+} from './activityPolicyRegistry';
+
+describe('activityPolicyRegistry', () => {
+    it('resolves v1 retry policy definitions', () => {
+        expect(getRetryPolicyDefinition('none')).toEqual(
+            expect.objectContaining({ maximumAttempts: 1 })
+        );
+        expect(getRetryPolicyDefinition('agent_standard')).toEqual(
+            expect.objectContaining({
+                maximumAttempts: 3,
+                initialIntervalMs: 1_000,
+                maximumIntervalMs: 30_000,
+            })
+        );
+        expect(getRetryPolicyDefinition('agent_startup')).toEqual(
+            expect.objectContaining({
+                maximumAttempts: 5,
+                maximumIntervalMs: 10_000,
+            })
+        );
+        expect(getRetryPolicyDefinition('integration_transient')).toEqual(
+            expect.objectContaining({
+                maximumAttempts: 3,
+                initialIntervalMs: 2_000,
+                maximumIntervalMs: 60_000,
+            })
+        );
+    });
+
+    it('resolves v1 timeout policy definitions', () => {
+        expect(getTimeoutPolicyDefinition('agent_short')).toEqual(
+            expect.objectContaining({
+                startToCloseMs: 5 * 60 * 1_000,
+                scheduleToCloseMs: 10 * 60 * 1_000,
+            })
+        );
+        expect(getTimeoutPolicyDefinition('agent_default')).toEqual(
+            expect.objectContaining({
+                startToCloseMs: 30 * 60 * 1_000,
+                scheduleToCloseMs: 45 * 60 * 1_000,
+            })
+        );
+        expect(getTimeoutPolicyDefinition('agent_long')).toEqual(
+            expect.objectContaining({
+                startToCloseMs: 2 * 60 * 60 * 1_000,
+                scheduleToCloseMs: (2 * 60 + 15) * 60 * 1_000,
+            })
+        );
+    });
+
+    it('applies workflow defaults when node policies are omitted', () => {
+        expect(resolveRetryPolicyId({})).toBe(DEFAULT_RETRY_POLICY_ID);
+        expect(resolveTimeoutPolicyId({})).toBe(DEFAULT_TIMEOUT_POLICY_ID);
+    });
+
+    it('uses explicit node policy references when present', () => {
+        expect(resolveRetryPolicyId({ retry_policy: 'none' })).toBe('none');
+        expect(resolveTimeoutPolicyId({ timeout_policy: 'agent_long' })).toBe('agent_long');
+    });
+
+    it('recognizes catalog policy ids', () => {
+        expect(isKnownRetryPolicyId('agent_standard')).toBe(true);
+        expect(isKnownRetryPolicyId('unknown')).toBe(false);
+        expect(isKnownTimeoutPolicyId('agent_default')).toBe(true);
+        expect(isKnownTimeoutPolicyId('unknown')).toBe(false);
+    });
+
+    it('never retries cancelled activities', () => {
+        expect(shouldRetryActivityResponse('cancelled', false, 'agent_standard')).toBe(false);
+        expect(shouldRetryActivityResponse('cancelled', true, 'agent_startup')).toBe(false);
+    });
+
+    it('does not retry when retryable=false', () => {
+        expect(shouldRetryActivityResponse('startup', false, 'agent_standard')).toBe(false);
+        expect(shouldRetryActivityResponse('execution', false, 'agent_standard')).toBe(false);
+    });
+
+    it('retries retryable startup failures for agent_standard', () => {
+        expect(shouldRetryActivityResponse('startup', true, 'agent_standard')).toBe(true);
+    });
+
+    it('does not retry execution failures for agent_startup', () => {
+        expect(shouldRetryActivityResponse('execution', true, 'agent_startup')).toBe(false);
+    });
+
+    it('retries retryable execution failures for agent_standard', () => {
+        expect(shouldRetryActivityResponse('execution', true, 'agent_standard')).toBe(true);
+    });
+
+    it('never retries when policy is none', () => {
+        expect(shouldRetryActivityResponse('startup', true, 'none')).toBe(false);
+    });
+});

--- a/src/workflows/activityPolicyRegistry.ts
+++ b/src/workflows/activityPolicyRegistry.ts
@@ -1,0 +1,150 @@
+export type ActivityFailureClass = 'startup' | 'execution' | 'cancelled';
+
+export const DEFAULT_RETRY_POLICY_ID = 'agent_standard';
+export const DEFAULT_TIMEOUT_POLICY_ID = 'agent_default';
+
+export const V1_RETRY_POLICY_IDS = [
+    'none',
+    'agent_standard',
+    'agent_startup',
+    'integration_transient',
+] as const;
+
+export const V1_TIMEOUT_POLICY_IDS = ['agent_short', 'agent_default', 'agent_long'] as const;
+
+export type V1RetryPolicyId = (typeof V1_RETRY_POLICY_IDS)[number];
+export type V1TimeoutPolicyId = (typeof V1_TIMEOUT_POLICY_IDS)[number];
+
+export interface ForgeRetryPolicyDefinition {
+    policy_id: V1RetryPolicyId;
+    maximumAttempts: number;
+    initialIntervalMs: number;
+    maximumIntervalMs: number;
+    backoffCoefficient: number;
+    nonRetryableFailureClasses: ActivityFailureClass[];
+}
+
+export interface ForgeTimeoutPolicyDefinition {
+    policy_id: V1TimeoutPolicyId;
+    startToCloseMs: number;
+    scheduleToCloseMs: number;
+}
+
+const V1_RETRY_POLICIES: Record<V1RetryPolicyId, ForgeRetryPolicyDefinition> = {
+    none: {
+        policy_id: 'none',
+        maximumAttempts: 1,
+        initialIntervalMs: 1_000,
+        maximumIntervalMs: 1_000,
+        backoffCoefficient: 1,
+        nonRetryableFailureClasses: ['startup', 'execution', 'cancelled'],
+    },
+    agent_standard: {
+        policy_id: 'agent_standard',
+        maximumAttempts: 3,
+        initialIntervalMs: 1_000,
+        maximumIntervalMs: 30_000,
+        backoffCoefficient: 2,
+        nonRetryableFailureClasses: ['cancelled'],
+    },
+    agent_startup: {
+        policy_id: 'agent_startup',
+        maximumAttempts: 5,
+        initialIntervalMs: 1_000,
+        maximumIntervalMs: 10_000,
+        backoffCoefficient: 2,
+        nonRetryableFailureClasses: ['execution', 'cancelled'],
+    },
+    integration_transient: {
+        policy_id: 'integration_transient',
+        maximumAttempts: 3,
+        initialIntervalMs: 2_000,
+        maximumIntervalMs: 60_000,
+        backoffCoefficient: 2,
+        nonRetryableFailureClasses: ['cancelled'],
+    },
+};
+
+const V1_TIMEOUT_POLICIES: Record<V1TimeoutPolicyId, ForgeTimeoutPolicyDefinition> = {
+    agent_short: {
+        policy_id: 'agent_short',
+        startToCloseMs: 5 * 60 * 1_000,
+        scheduleToCloseMs: 10 * 60 * 1_000,
+    },
+    agent_default: {
+        policy_id: 'agent_default',
+        startToCloseMs: 30 * 60 * 1_000,
+        scheduleToCloseMs: 45 * 60 * 1_000,
+    },
+    agent_long: {
+        policy_id: 'agent_long',
+        startToCloseMs: 2 * 60 * 60 * 1_000,
+        scheduleToCloseMs: (2 * 60 + 15) * 60 * 1_000,
+    },
+};
+
+export interface ActivityNodePolicyRefs {
+    retry_policy?: string;
+    timeout_policy?: string;
+}
+
+export function isKnownRetryPolicyId(policyId: string): policyId is V1RetryPolicyId {
+    return (V1_RETRY_POLICY_IDS as readonly string[]).includes(policyId);
+}
+
+export function isKnownTimeoutPolicyId(policyId: string): policyId is V1TimeoutPolicyId {
+    return (V1_TIMEOUT_POLICY_IDS as readonly string[]).includes(policyId);
+}
+
+export function resolveRetryPolicyId(node: ActivityNodePolicyRefs): V1RetryPolicyId {
+    const policyId = node.retry_policy?.trim();
+    if (policyId && isKnownRetryPolicyId(policyId)) {
+        return policyId;
+    }
+    return DEFAULT_RETRY_POLICY_ID;
+}
+
+export function resolveTimeoutPolicyId(node: ActivityNodePolicyRefs): V1TimeoutPolicyId {
+    const policyId = node.timeout_policy?.trim();
+    if (policyId && isKnownTimeoutPolicyId(policyId)) {
+        return policyId;
+    }
+    return DEFAULT_TIMEOUT_POLICY_ID;
+}
+
+export function getRetryPolicyDefinition(policyId: V1RetryPolicyId): ForgeRetryPolicyDefinition {
+    return V1_RETRY_POLICIES[policyId];
+}
+
+export function getTimeoutPolicyDefinition(policyId: V1TimeoutPolicyId): ForgeTimeoutPolicyDefinition {
+    return V1_TIMEOUT_POLICIES[policyId];
+}
+
+export function lookupRetryPolicyDefinition(policyId: string): ForgeRetryPolicyDefinition | undefined {
+    return isKnownRetryPolicyId(policyId) ? V1_RETRY_POLICIES[policyId] : undefined;
+}
+
+export function lookupTimeoutPolicyDefinition(policyId: string): ForgeTimeoutPolicyDefinition | undefined {
+    return isKnownTimeoutPolicyId(policyId) ? V1_TIMEOUT_POLICIES[policyId] : undefined;
+}
+
+export function shouldRetryActivityResponse(
+    failureClass: ActivityFailureClass | undefined,
+    retryable: boolean,
+    retryPolicyId: V1RetryPolicyId
+): boolean {
+    if (retryPolicyId === 'none') {
+        return false;
+    }
+
+    if (failureClass === 'cancelled' || !retryable) {
+        return false;
+    }
+
+    const policy = getRetryPolicyDefinition(retryPolicyId);
+    if (failureClass && policy.nonRetryableFailureClasses.includes(failureClass)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,4 +1,20 @@
 export {
+    DEFAULT_RETRY_POLICY_ID,
+    DEFAULT_TIMEOUT_POLICY_ID,
+    getRetryPolicyDefinition,
+    getTimeoutPolicyDefinition,
+    isKnownRetryPolicyId,
+    isKnownTimeoutPolicyId,
+    lookupRetryPolicyDefinition,
+    lookupTimeoutPolicyDefinition,
+    resolveRetryPolicyId,
+    resolveTimeoutPolicyId,
+    shouldRetryActivityResponse,
+    V1_RETRY_POLICY_IDS,
+    V1_TIMEOUT_POLICY_IDS,
+} from './activityPolicyRegistry';
+export type { ActivityNodePolicyRefs, V1RetryPolicyId, V1TimeoutPolicyId } from './activityPolicyRegistry';
+export {
     discoverWorkflowDefinitions,
     WORKFLOW_DUPLICATE_ID_VALIDATOR_ID,
 } from './discoverWorkflowDefinitions';

--- a/src/workflows/validateWorkflowDomain.test.ts
+++ b/src/workflows/validateWorkflowDomain.test.ts
@@ -225,4 +225,64 @@ describe('validateWorkflowDomain', () => {
         expect(result.valid).toBe(true);
         expect(result.diagnostics).toEqual([]);
     });
+
+    it('reports unknown retry and timeout policy references', () => {
+        const content = {
+            schema_version: '1.0.0',
+            workflow_id: 'policy-test',
+            name: 'Policy Test',
+            version: '1.0.0',
+            entry_node_id: 'start',
+            retry_policies: [{ policy_id: 'not-a-policy' }],
+            timeout_policies: [{ policy_id: 'also-unknown' }],
+            nodes: [
+                {
+                    node_id: 'start',
+                    type: 'activity',
+                    name: 'Start',
+                    activity_id: 'forge.test.start',
+                    agent_path: 'resources/workflow/agents/technical-writer.md',
+                    retry_policy: 'missing-retry',
+                    timeout_policy: 'missing-timeout',
+                    transitions: [{ to_node_id: 'done' }],
+                },
+                {
+                    node_id: 'done',
+                    type: 'terminal',
+                    name: 'Done',
+                },
+            ],
+        };
+
+        const result = validateWorkflowDomain(content, {
+            path: '.ai/workflows/policy-test.json',
+            workspaceRoot: process.cwd(),
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'binding.unknown_retry_policy_id',
+                    path: '/retry_policies/0/policy_id',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+                expect.objectContaining({
+                    code: 'binding.unknown_timeout_policy_id',
+                    path: '/timeout_policies/0/policy_id',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+                expect.objectContaining({
+                    code: 'binding.unresolved_retry_policy',
+                    path: '/nodes/0/retry_policy',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+                expect.objectContaining({
+                    code: 'binding.unresolved_timeout_policy',
+                    path: '/nodes/0/timeout_policy',
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
 });

--- a/src/workflows/validateWorkflowDomain.ts
+++ b/src/workflows/validateWorkflowDomain.ts
@@ -1,5 +1,11 @@
 import fs from 'fs';
 import path from 'path';
+import {
+    isKnownRetryPolicyId,
+    isKnownTimeoutPolicyId,
+    V1_RETRY_POLICY_IDS,
+    V1_TIMEOUT_POLICY_IDS,
+} from './activityPolicyRegistry';
 import type { WorkflowDiagnostic, WorkflowSchemaValidationResult } from './types';
 
 export const WORKFLOW_GRAPH_VALIDATOR_ID = 'forge.workflow.graph';
@@ -280,28 +286,54 @@ function validateBindings(
         }
     }
 
-    const retryPolicyIds = new Set<string>();
+    const retryPolicyIds = new Set<string>(V1_RETRY_POLICY_IDS);
     const retryPolicies = content.retry_policies;
     if (Array.isArray(retryPolicies)) {
-        for (const policy of retryPolicies) {
+        retryPolicies.forEach((policy, policyIndex) => {
             const record = readRecord(policy);
             const policyId = record ? readString(record.policy_id) : undefined;
-            if (policyId) {
-                retryPolicyIds.add(policyId);
+            if (!policyId) {
+                return;
             }
-        }
+
+            if (!isKnownRetryPolicyId(policyId)) {
+                diagnostics.push({
+                    code: 'binding.unknown_retry_policy_id',
+                    severity: 'error',
+                    path: `/retry_policies/${policyIndex}/policy_id`,
+                    message: `retry policy_id "${policyId}" is not in the v1 catalog (${V1_RETRY_POLICY_IDS.join(', ')})`,
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                });
+                return;
+            }
+
+            retryPolicyIds.add(policyId);
+        });
     }
 
-    const timeoutPolicyIds = new Set<string>();
+    const timeoutPolicyIds = new Set<string>(V1_TIMEOUT_POLICY_IDS);
     const timeoutPolicies = content.timeout_policies;
     if (Array.isArray(timeoutPolicies)) {
-        for (const policy of timeoutPolicies) {
+        timeoutPolicies.forEach((policy, policyIndex) => {
             const record = readRecord(policy);
             const policyId = record ? readString(record.policy_id) : undefined;
-            if (policyId) {
-                timeoutPolicyIds.add(policyId);
+            if (!policyId) {
+                return;
             }
-        }
+
+            if (!isKnownTimeoutPolicyId(policyId)) {
+                diagnostics.push({
+                    code: 'binding.unknown_timeout_policy_id',
+                    severity: 'error',
+                    path: `/timeout_policies/${policyIndex}/policy_id`,
+                    message: `timeout policy_id "${policyId}" is not in the v1 catalog (${V1_TIMEOUT_POLICY_IDS.join(', ')})`,
+                    validator_id: WORKFLOW_BINDING_VALIDATOR_ID,
+                });
+                return;
+            }
+
+            timeoutPolicyIds.add(policyId);
+        });
     }
 
     nodes.forEach((node, nodeIndex) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ const workerConfig = {
     },
     externals: {
         '@temporalio/activity': 'commonjs @temporalio/activity',
+        '@temporalio/common': 'commonjs @temporalio/common',
         '@temporalio/worker': 'commonjs @temporalio/worker',
         '@cursor/sdk': 'commonjs @cursor/sdk',
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 /**@type {import('webpack').Configuration}*/
-const config = {
+const extensionConfig = {
     target: 'node',
     mode: 'none',
     entry: './src/extension.ts',
@@ -38,5 +38,44 @@ const config = {
     },
 };
 
-module.exports = config;
+/**@type {import('webpack').Configuration}*/
+const workerConfig = {
+    target: 'node',
+    mode: 'none',
+    entry: './src/worker/index.ts',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'worker.js',
+        libraryTarget: 'commonjs2'
+    },
+    externals: {
+        '@temporalio/activity': 'commonjs @temporalio/activity',
+        '@temporalio/worker': 'commonjs @temporalio/worker',
+        '@cursor/sdk': 'commonjs @cursor/sdk',
+    },
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            configFile: 'tsconfig.json'
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    devtool: 'nosources-source-map',
+    infrastructureLogging: {
+        level: "log",
+    },
+};
 
+module.exports = [extensionConfig, workerConfig];


### PR DESCRIPTION
## Description

Implements the Cursor SDK agent activity adapter and v1 retry/timeout policy mapping for parent issue #22.

### Sub-issue #46 — Cursor SDK activity adapter
- `executeCursorSdkAgentActivity` with v1 request/response envelope mapping
- Local runtime configuration, heartbeats, cancellation propagation
- Metadata-only `[forge.activity.cursor]` logging

### Sub-issue #47 — Retry and timeout policy classes
- v1 policy catalog (`none`, `agent_standard`, `agent_startup`, `integration_transient`; `agent_short`, `agent_default`, `agent_long`)
- Defaults `agent_standard` / `agent_default` when activity nodes omit policy references
- Maps SDK response envelopes to Temporal `ApplicationFailure` retry decisions (cancelled and `retryable=false` never retry)
- Pre-run binding validation rejects unknown `policy_id` references
- `buildTemporalActivityOptions()` for workflow-side activity invocation

## Motivation and Context

Forge workflow agent steps must run through the `@cursor/sdk` boundary with explicit inputs, outputs, retry semantics, and cancellation behavior. The extension host schedules work on the window-scoped worker; this PR wires the worker activity that invokes local SDK agents against the run-selected workspace root and applies the execution model policy catalog.

Fixes #46
Fixes #47

Related: #22

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] `npm run build` produces extension and worker bundles
- [x] `scripts/verify-packaging.sh` confirms worker bundle and `@cursor/sdk` in VSIX

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

## Additional Notes

- Worker resolves `CURSOR_API_KEY` from spawn env (SecretStorage injection or env override).
- Parent #22 remains open until all sub-issues on this branch are complete and CI is green.