### PR TITLE
feat(worker): Cursor SDK activity envelopes and response mapping (#23)

### DIFF
--- a/src/worker/activityEnvelope.ts
+++ b/src/worker/activityEnvelope.ts
@@ -14,6 +14,33 @@ export interface ActivityDiagnostic {
     source?: 'sdk' | 'worker' | 'validator';
 }
 
+export interface ActivityEnvelopeValidatorDiagnostic extends ActivityDiagnostic {
+    validator_id: string;
+}
+
+export interface ActivityArtifactRef {
+    artifact_id: string;
+    path: string;
+    size_bytes: number;
+    sha256: string;
+    media_type?: string;
+}
+
+export type ActivityFollowUpSeverity = 'blocker' | 'non-blocker';
+
+export interface ActivityFollowUpQuestion {
+    question_id: string;
+    prompt: string;
+    severity?: ActivityFollowUpSeverity;
+    domain?: string;
+}
+
+export interface ActivityValidationInputs {
+    schema_ref?: string;
+    artifact_ids?: string[];
+    domain_criteria?: string[];
+}
+
 export interface CursorSdkRequestEnvelope {
     envelope_version: string;
     activity_id: string;
@@ -42,7 +69,15 @@ export interface CursorSdkResponseEnvelope {
     failure_class?: ActivityFailureClass;
     retryable: boolean;
     structured_payload?: unknown;
+    artifact_refs?: ActivityArtifactRef[];
+    follow_up_questions?: ActivityFollowUpQuestion[];
     diagnostics?: ActivityDiagnostic[];
+    validation_inputs?: ActivityValidationInputs;
+}
+
+export interface ActivityEnvelopeValidationResult {
+    valid: boolean;
+    diagnostics: ActivityEnvelopeValidatorDiagnostic[];
 }
 
 export interface ExecuteCursorSdkAgentActivityInput {

--- a/src/worker/cursorActivityLog.ts
+++ b/src/worker/cursorActivityLog.ts
@@ -67,6 +67,7 @@ export function createCursorActivityLogger(
                     status: envelope.status,
                     failure_class: envelope.failure_class,
                     retryable: envelope.retryable,
+                    artifact_ref_paths: envelope.artifact_refs?.map((artifactRef) => artifactRef.path),
                 })
             );
         },

--- a/src/worker/executeCursorSdkAgentActivity.test.ts
+++ b/src/worker/executeCursorSdkAgentActivity.test.ts
@@ -91,6 +91,43 @@ describe('executeCursorSdkAgentActivity', () => {
         expect(heartbeatMock).toHaveBeenCalledWith({ cursor_run_id: 'run-456' });
     });
 
+    it('writes artifact_refs when node declares artifact_ids', async () => {
+        process.env.CURSOR_API_KEY = 'cursor_test_key';
+
+        const createAgent = vi.fn(async () => ({
+            agentId: 'agent-123',
+            send: vi.fn(async () => ({
+                id: 'run-456',
+                supports: () => true,
+                wait: vi.fn(async () => ({
+                    id: 'run-456',
+                    status: 'finished',
+                    result: '# Artifact output',
+                })),
+            })),
+            close: vi.fn(),
+            [Symbol.asyncDispose]: vi.fn(async () => undefined),
+        }));
+
+        const response = await executeCursorSdkAgentActivity(
+            {
+                envelope: {
+                    ...envelope,
+                    artifact_ids: ['refinement'],
+                },
+                workspaceRoot: '/tmp/workspace',
+            },
+            {
+                createAgent,
+                log: () => undefined,
+            }
+        );
+
+        expect(response.status).toBe('finished');
+        expect(response.structured_payload).toBeUndefined();
+        expect(response.artifact_refs?.[0]?.artifact_id).toBe('refinement');
+    });
+
     it('maps CursorAgentError to startup failure envelope', async () => {
         process.env.CURSOR_API_KEY = 'cursor_test_key';
 

--- a/src/worker/executeCursorSdkAgentActivity.ts
+++ b/src/worker/executeCursorSdkAgentActivity.ts
@@ -15,6 +15,7 @@ import {
     buildResponseShell,
     buildStartupFailureResponse,
     buildSuccessResponse,
+    prepareActivityResponse,
 } from './mapSdkOutcome';
 import { resolveCursorApiKeyFromEnv } from './resolveCursorApiKey';
 
@@ -93,7 +94,7 @@ export async function executeCursorSdkAgentActivity(
 
     const apiKey = resolveCursorApiKeyFromEnv();
     if (!apiKey) {
-        const response = buildMissingApiKeyResponse(envelope);
+        const response = prepareActivityResponse(buildMissingApiKeyResponse(envelope));
         activityLogger.logResponseEnvelope(response);
         return response;
     }
@@ -132,26 +133,31 @@ export async function executeCursorSdkAgentActivity(
         }
 
         if (cancelled || result.status === 'cancelled') {
-            const response = buildCancelledResponse(shell);
+            const response = prepareActivityResponse(buildCancelledResponse(shell));
             activityLogger.logResponseEnvelope(response);
             return response;
         }
 
         if (result.status === 'error') {
-            const response = buildExecutionFailureResponse(shell, result, false);
+            const response = prepareActivityResponse(buildExecutionFailureResponse(shell, result));
             activityLogger.logResponseEnvelope(response);
             return response;
         }
 
-        const response = buildSuccessResponse(shell, result, envelope.output_type);
+        const response = buildSuccessResponse(shell, result, envelope.output_type, {
+            requestEnvelope: envelope,
+            workspaceRoot,
+        });
         activityLogger.logResponseEnvelope(response);
         return response;
     } catch (error) {
         if (error instanceof CursorAgentError) {
-            const response = buildStartupFailureResponse(
-                buildResponseShell(envelope, agent?.agentId ?? 'unavailable', 'unavailable'),
-                error.message,
-                error.isRetryable
+            const response = prepareActivityResponse(
+                buildStartupFailureResponse(
+                    buildResponseShell(envelope, agent?.agentId ?? 'unavailable', 'unavailable'),
+                    error.message,
+                    error.isRetryable
+                )
             );
             activityLogger.logResponseEnvelope(response);
             return response;

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -28,7 +28,25 @@ export { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
 export { buildTemporalActivityOptions } from './temporalActivityPolicyOptions';
 export { mapEnvelopeToActivityFailure } from './mapEnvelopeToActivityFailure';
 export type {
+    ActivityArtifactRef,
+    ActivityEnvelopeValidationResult,
+    ActivityEnvelopeValidatorDiagnostic,
+    ActivityFollowUpQuestion,
+    ActivityValidationInputs,
     CursorSdkRequestEnvelope,
     CursorSdkResponseEnvelope,
     ExecuteCursorSdkAgentActivityInput,
 } from './activityEnvelope';
+export {
+    validateActivityEnvelope,
+    validateEnvelopeSchema,
+    validateEnvelopeUnsupportedVersion,
+    validateEnvelopeSize,
+    ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+    INLINE_STRUCTURED_PAYLOAD_MAX_BYTES,
+    TOTAL_ENVELOPE_MAX_BYTES,
+    ENVELOPE_UNSUPPORTED_VERSION_CODE,
+    ENVELOPE_SIZE_EXCEEDED_CODE,
+} from './validateActivityEnvelope';

--- a/src/worker/mapSdkOutcome.test.ts
+++ b/src/worker/mapSdkOutcome.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import type { CursorSdkRequestEnvelope } from './activityEnvelope';
 import {
+    buildEnvelopeSizeExceededResponse,
     buildMissingApiKeyResponse,
     buildSuccessResponse,
+    extractFollowUpQuestions,
     parseStructuredPayload,
+    resolveActivityArtifactRelativePath,
+    sha256Hex,
+    shouldSpillToArtifact,
+    structuredPayloadUtf8Bytes,
+    writeActivityArtifact,
 } from './mapSdkOutcome';
+import {
+    INLINE_STRUCTURED_PAYLOAD_MAX_BYTES,
+    TOTAL_ENVELOPE_MAX_BYTES,
+} from './validateActivityEnvelope';
 
 const baseEnvelope: CursorSdkRequestEnvelope = {
     envelope_version: '1.0.0',
@@ -15,6 +26,19 @@ const baseEnvelope: CursorSdkRequestEnvelope = {
     prompt: 'Do work',
     inputs: {},
     output_type: 'json',
+};
+
+const responseShell = {
+    envelope_version: '1.0.0',
+    activity_id: baseEnvelope.activity_id,
+    node_id: baseEnvelope.node_id,
+    workflow_run_id: baseEnvelope.workflow_run_id,
+    cursor_agent_id: 'agent-1',
+    cursor_run_id: 'run-abc',
+    skill_path: baseEnvelope.skill_path,
+    output_type: baseEnvelope.output_type,
+    status: 'error' as const,
+    retryable: false,
 };
 
 describe('mapSdkOutcome', () => {
@@ -37,22 +61,9 @@ describe('mapSdkOutcome', () => {
         expect(payload).toBe('# Done');
     });
 
-    it('builds finished response with structured payload', () => {
-        const shell = {
-            envelope_version: '1.0.0',
-            activity_id: baseEnvelope.activity_id,
-            node_id: baseEnvelope.node_id,
-            workflow_run_id: baseEnvelope.workflow_run_id,
-            cursor_agent_id: 'agent-1',
-            cursor_run_id: 'run-abc',
-            skill_path: baseEnvelope.skill_path,
-            output_type: baseEnvelope.output_type,
-            status: 'error' as const,
-            retryable: false,
-        };
-
+    it('builds finished response with inline structured payload', () => {
         const response = buildSuccessResponse(
-            shell,
+            responseShell,
             { id: 'run-abc', status: 'finished', result: '{"done":true}' },
             'json'
         );
@@ -60,5 +71,194 @@ describe('mapSdkOutcome', () => {
         expect(response.status).toBe('finished');
         expect(response.structured_payload).toEqual({ done: true });
         expect(response.failure_class).toBeUndefined();
+        expect(response.artifact_refs).toBeUndefined();
+    });
+
+    it('spills oversized payload to artifact_refs without inline body', () => {
+        const oversized = 'x'.repeat(INLINE_STRUCTURED_PAYLOAD_MAX_BYTES + 1);
+        const writes: Array<{ path: string; content: string }> = [];
+        const response = buildSuccessResponse(
+            responseShell,
+            { id: 'run-abc', status: 'finished', result: JSON.stringify({ body: oversized }) },
+            'json',
+            {
+                requestEnvelope: baseEnvelope,
+                workspaceRoot: '/tmp/workspace',
+                artifactWriter: {
+                    mkdirSync: () => undefined,
+                    writeFileSync: (filePath, content) => {
+                        writes.push({ path: filePath, content });
+                    },
+                },
+            }
+        );
+
+        expect(response.status).toBe('finished');
+        expect(response.structured_payload).toBeUndefined();
+        expect(response.artifact_refs).toHaveLength(1);
+        expect(response.artifact_refs?.[0]).toEqual(
+            expect.objectContaining({
+                artifact_id: 'activity-output',
+                path: resolveActivityArtifactRelativePath(
+                    baseEnvelope.workflow_run_id,
+                    baseEnvelope.node_id,
+                    'activity-output',
+                    'json'
+                ),
+                size_bytes: structuredPayloadUtf8Bytes({ body: oversized }, 'json'),
+                sha256: sha256Hex(JSON.stringify({ body: oversized })),
+                media_type: 'application/json',
+            })
+        );
+        expect(writes).toHaveLength(1);
+    });
+
+    it('writes artifact_refs when request declares artifact_ids even for small payloads', () => {
+        const response = buildSuccessResponse(
+            responseShell,
+            { id: 'run-abc', status: 'finished', result: '# Done' },
+            'markdown',
+            {
+                requestEnvelope: {
+                    ...baseEnvelope,
+                    output_type: 'markdown',
+                    artifact_ids: ['refinement'],
+                },
+                workspaceRoot: '/tmp/workspace',
+                artifactWriter: {
+                    mkdirSync: () => undefined,
+                    writeFileSync: () => undefined,
+                },
+            }
+        );
+
+        expect(response.structured_payload).toBeUndefined();
+        expect(response.artifact_refs?.[0]?.artifact_id).toBe('refinement');
+        expect(response.artifact_refs?.[0]?.path).toBe(
+            resolveActivityArtifactRelativePath(
+                baseEnvelope.workflow_run_id,
+                baseEnvelope.node_id,
+                'refinement',
+                'markdown'
+            )
+        );
+    });
+
+    it('extracts follow_up_questions from json output', () => {
+        const extracted = extractFollowUpQuestions(
+            {
+                summary: 'done',
+                follow_up_questions: [
+                    {
+                        question_id: 'auth-scope',
+                        prompt: 'Which GitHub scopes are required?',
+                        severity: 'blocker',
+                    },
+                ],
+            },
+            undefined
+        );
+
+        expect(extracted.structuredPayload).toEqual({ summary: 'done' });
+        expect(extracted.followUpQuestions).toEqual([
+            {
+                question_id: 'auth-scope',
+                prompt: 'Which GitHub scopes are required?',
+                severity: 'blocker',
+            },
+        ]);
+    });
+
+    it('skips follow_up_questions when user_questions artifact is declared', () => {
+        const extracted = extractFollowUpQuestions(
+            {
+                follow_up_questions: [{ question_id: 'q1', prompt: 'Question?' }],
+            },
+            ['user_questions']
+        );
+
+        expect(extracted.followUpQuestions).toBeUndefined();
+        expect(extracted.structuredPayload).toEqual({
+            follow_up_questions: [{ question_id: 'q1', prompt: 'Question?' }],
+        });
+    });
+
+    it('includes follow_up_questions on finished response', () => {
+        const response = buildSuccessResponse(
+            responseShell,
+            {
+                id: 'run-abc',
+                status: 'finished',
+                result: JSON.stringify({
+                    follow_up_questions: [{ question_id: 'next-step', prompt: 'Continue?' }],
+                }),
+            },
+            'json'
+        );
+
+        expect(response.follow_up_questions).toEqual([
+            { question_id: 'next-step', prompt: 'Continue?' },
+        ]);
+        expect(response.structured_payload).toBeUndefined();
+    });
+
+    it('returns execution failure when serialized envelope exceeds 256 KiB', () => {
+        const hugeField = 'z'.repeat(TOTAL_ENVELOPE_MAX_BYTES);
+        const response = buildSuccessResponse(
+            responseShell,
+            {
+                id: 'run-abc',
+                status: 'finished',
+                result: JSON.stringify({ hugeField }),
+            },
+            'json'
+        );
+
+        expect(response.status).toBe('error');
+        expect(response.failure_class).toBe('execution');
+        expect(response.retryable).toBe(true);
+        expect(response.diagnostics?.[0]?.code).toBe('forge.envelope.size_exceeded');
+        expect(response.structured_payload).toBeUndefined();
+    });
+
+    it('builds explicit envelope size exceeded response', () => {
+        const response = buildEnvelopeSizeExceededResponse(responseShell, TOTAL_ENVELOPE_MAX_BYTES + 1);
+
+        expect(response.status).toBe('error');
+        expect(response.failure_class).toBe('execution');
+        expect(response.diagnostics?.[0]?.code).toBe('forge.envelope.size_exceeded');
+    });
+
+    it('writes artifact files with sha256 and size metadata', () => {
+        const writes: Array<{ path: string; content: string }> = [];
+        const artifactRef = writeActivityArtifact(
+            '/tmp/workspace',
+            '.cursor/.tmp/forge-activities/run-1/node-1/refinement.md',
+            '# Output',
+            'refinement',
+            'markdown',
+            {
+                mkdirSync: () => undefined,
+                writeFileSync: (filePath, content) => {
+                    writes.push({ path: filePath, content });
+                },
+            }
+        );
+
+        expect(artifactRef).toEqual({
+            artifact_id: 'refinement',
+            path: '.cursor/.tmp/forge-activities/run-1/node-1/refinement.md',
+            size_bytes: 8,
+            sha256: sha256Hex('# Output'),
+            media_type: 'text/markdown',
+        });
+        expect(writes[0]?.content).toBe('# Output');
+    });
+
+    it('detects spill when payload exceeds inline cap', () => {
+        const payload = 'a'.repeat(INLINE_STRUCTURED_PAYLOAD_MAX_BYTES + 1);
+        expect(shouldSpillToArtifact(payload, 'text', undefined)).toBe(true);
+        expect(shouldSpillToArtifact('small', 'text', undefined)).toBe(false);
+        expect(shouldSpillToArtifact('small', 'text', ['issue_context'])).toBe(true);
     });
 });

--- a/src/worker/mapSdkOutcome.ts
+++ b/src/worker/mapSdkOutcome.ts
@@ -1,10 +1,44 @@
 import type { RunResult } from '@cursor/sdk';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import {
     ACTIVITY_ENVELOPE_VERSION,
+    type ActivityArtifactRef,
+    type ActivityFollowUpQuestion,
     type ActivityOutputType,
     type CursorSdkRequestEnvelope,
     type CursorSdkResponseEnvelope,
 } from './activityEnvelope';
+import {
+    ENVELOPE_SIZE_EXCEEDED_CODE,
+    INLINE_STRUCTURED_PAYLOAD_MAX_BYTES,
+    TOTAL_ENVELOPE_MAX_BYTES,
+    validateActivityEnvelope,
+} from './validateActivityEnvelope';
+
+const USER_QUESTIONS_ARTIFACT_ID = 'user_questions';
+const DEFAULT_ACTIVITY_OUTPUT_ARTIFACT_ID = 'activity-output';
+
+export interface ActivityArtifactWriter {
+    mkdirSync: (directory: string, options: { recursive: boolean }) => void;
+    writeFileSync: (filePath: string, data: string) => void;
+}
+
+export interface BuildSuccessResponseOptions {
+    requestEnvelope: CursorSdkRequestEnvelope;
+    workspaceRoot: string;
+    artifactWriter?: ActivityArtifactWriter;
+}
+
+function defaultArtifactWriter(): ActivityArtifactWriter {
+    return {
+        mkdirSync: fs.mkdirSync,
+        writeFileSync: (filePath, data) => {
+            fs.writeFileSync(filePath, data, 'utf8');
+        },
+    };
+}
 
 export function buildResponseShell(
     envelope: CursorSdkRequestEnvelope,
@@ -74,10 +108,18 @@ export function buildStartupFailureResponse(
     };
 }
 
+function resolveRunResultRetryable(result: RunResult): boolean {
+    if ('isRetryable' in result && typeof result.isRetryable === 'boolean') {
+        return result.isRetryable;
+    }
+
+    return false;
+}
+
 export function buildExecutionFailureResponse(
     shell: CursorSdkResponseEnvelope,
     result: RunResult,
-    retryable: boolean
+    retryable: boolean = resolveRunResultRetryable(result)
 ): CursorSdkResponseEnvelope {
     return {
         ...shell,
@@ -112,6 +154,29 @@ export function buildCancelledResponse(shell: CursorSdkResponseEnvelope): Cursor
     };
 }
 
+export function buildEnvelopeSizeExceededResponse(
+    shell: CursorSdkResponseEnvelope,
+    totalBytes: number
+): CursorSdkResponseEnvelope {
+    return {
+        ...shell,
+        status: 'error',
+        failure_class: 'execution',
+        retryable: true,
+        structured_payload: undefined,
+        artifact_refs: undefined,
+        follow_up_questions: undefined,
+        diagnostics: [
+            {
+                code: ENVELOPE_SIZE_EXCEEDED_CODE,
+                message: `serialized envelope exceeds total limit (${totalBytes} bytes; max ${TOTAL_ENVELOPE_MAX_BYTES})`,
+                severity: 'error',
+                source: 'worker',
+            },
+        ],
+    };
+}
+
 export function parseStructuredPayload(
     outputType: ActivityOutputType,
     resultText: string | undefined
@@ -131,15 +196,242 @@ export function parseStructuredPayload(
     return resultText;
 }
 
+export function serializePayloadContent(payload: unknown, outputType: ActivityOutputType): string {
+    if (outputType === 'json') {
+        return JSON.stringify(payload);
+    }
+
+    if (payload === undefined) {
+        return '';
+    }
+
+    return String(payload);
+}
+
+export function extensionForOutputType(outputType: ActivityOutputType): string {
+    switch (outputType) {
+        case 'json':
+            return 'json';
+        case 'markdown':
+            return 'md';
+        case 'text':
+            return 'txt';
+    }
+}
+
+export function mediaTypeForOutputType(outputType: ActivityOutputType): string {
+    switch (outputType) {
+        case 'json':
+            return 'application/json';
+        case 'markdown':
+            return 'text/markdown';
+        case 'text':
+            return 'text/plain';
+    }
+}
+
+export function structuredPayloadUtf8Bytes(
+    payload: unknown,
+    outputType: ActivityOutputType
+): number {
+    return Buffer.byteLength(serializePayloadContent(payload, outputType), 'utf8');
+}
+
+export function resolveActivityArtifactRelativePath(
+    workflowRunId: string,
+    nodeId: string,
+    artifactId: string,
+    outputType: ActivityOutputType
+): string {
+    const extension = extensionForOutputType(outputType);
+    return `.cursor/.tmp/forge-activities/${workflowRunId}/${nodeId}/${artifactId}.${extension}`;
+}
+
+export function sha256Hex(content: string): string {
+    return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+export function writeActivityArtifact(
+    workspaceRoot: string,
+    relativePath: string,
+    content: string,
+    artifactId: string,
+    outputType: ActivityOutputType,
+    writer: ActivityArtifactWriter = defaultArtifactWriter()
+): ActivityArtifactRef {
+    const absolutePath = path.join(workspaceRoot, relativePath);
+    writer.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writer.writeFileSync(absolutePath, content);
+
+    const sizeBytes = Buffer.byteLength(content, 'utf8');
+    return {
+        artifact_id: artifactId,
+        path: relativePath.replace(/\\/g, '/'),
+        size_bytes: sizeBytes,
+        sha256: sha256Hex(content),
+        media_type: mediaTypeForOutputType(outputType),
+    };
+}
+
+export function shouldSpillToArtifact(
+    payload: unknown,
+    outputType: ActivityOutputType,
+    artifactIds: string[] | undefined
+): boolean {
+    if (artifactIds && artifactIds.length > 0) {
+        return true;
+    }
+
+    return structuredPayloadUtf8Bytes(payload, outputType) > INLINE_STRUCTURED_PAYLOAD_MAX_BYTES;
+}
+
+export function extractFollowUpQuestions(
+    payload: unknown,
+    artifactIds: string[] | undefined
+): {
+    structuredPayload: unknown | undefined;
+    followUpQuestions?: ActivityFollowUpQuestion[];
+} {
+    if (artifactIds?.includes(USER_QUESTIONS_ARTIFACT_ID)) {
+        return { structuredPayload: payload };
+    }
+
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return { structuredPayload: payload };
+    }
+
+    const record = payload as Record<string, unknown>;
+    const rawQuestions = record.follow_up_questions;
+    if (!Array.isArray(rawQuestions)) {
+        return { structuredPayload: payload };
+    }
+
+    const followUpQuestions: ActivityFollowUpQuestion[] = [];
+    for (const item of rawQuestions) {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+            continue;
+        }
+
+        const question = item as Record<string, unknown>;
+        const questionId = typeof question.question_id === 'string' ? question.question_id : undefined;
+        const prompt = typeof question.prompt === 'string' ? question.prompt : undefined;
+        if (!questionId || !prompt) {
+            continue;
+        }
+
+        followUpQuestions.push({
+            question_id: questionId,
+            prompt,
+            ...(question.severity === 'blocker' || question.severity === 'non-blocker'
+                ? { severity: question.severity }
+                : {}),
+            ...(typeof question.domain === 'string' ? { domain: question.domain } : {}),
+        });
+    }
+
+    const { follow_up_questions: _removed, ...rest } = record;
+    const structuredPayload = Object.keys(rest).length > 0 ? rest : undefined;
+
+    return {
+        structuredPayload,
+        followUpQuestions: followUpQuestions.length > 0 ? followUpQuestions : undefined,
+    };
+}
+
+export function finalizeActivityResponse(
+    envelope: CursorSdkResponseEnvelope
+): CursorSdkResponseEnvelope {
+    if (envelope.status === 'finished') {
+        const totalBytes = Buffer.byteLength(JSON.stringify(envelope), 'utf8');
+        if (totalBytes > TOTAL_ENVELOPE_MAX_BYTES) {
+            return buildEnvelopeSizeExceededResponse(envelope, totalBytes);
+        }
+    }
+
+    const validation = validateActivityEnvelope(envelope);
+    if (!validation.valid) {
+        const firstError = validation.diagnostics.find((diagnostic) => diagnostic.severity === 'error');
+        if (envelope.status === 'finished') {
+            return {
+                ...envelope,
+                status: 'error',
+                failure_class: 'execution',
+                retryable: false,
+                structured_payload: undefined,
+                artifact_refs: undefined,
+                follow_up_questions: undefined,
+                diagnostics: [
+                    {
+                        code: firstError?.code ?? 'forge.envelope.validation_failed',
+                        message: firstError?.message ?? 'activity envelope failed validation',
+                        severity: 'error',
+                        source: 'worker',
+                    },
+                ],
+            };
+        }
+    }
+
+    return envelope;
+}
+
+export function prepareActivityResponse(
+    envelope: CursorSdkResponseEnvelope
+): CursorSdkResponseEnvelope {
+    return finalizeActivityResponse(envelope);
+}
+
 export function buildSuccessResponse(
     shell: CursorSdkResponseEnvelope,
     result: RunResult,
-    outputType: ActivityOutputType
+    outputType: ActivityOutputType,
+    options?: BuildSuccessResponseOptions
 ): CursorSdkResponseEnvelope {
-    return {
+    const parsed = parseStructuredPayload(outputType, result.result);
+    const { structuredPayload, followUpQuestions } = extractFollowUpQuestions(
+        parsed,
+        options?.requestEnvelope.artifact_ids
+    );
+    const payloadForStorage = structuredPayload ?? parsed;
+
+    let response: CursorSdkResponseEnvelope = {
         ...shell,
         status: 'finished',
         retryable: false,
-        structured_payload: parseStructuredPayload(outputType, result.result),
     };
+
+    if (followUpQuestions) {
+        response.follow_up_questions = followUpQuestions;
+    }
+
+    const spill =
+        options !== undefined &&
+        shouldSpillToArtifact(payloadForStorage, outputType, options.requestEnvelope.artifact_ids);
+
+    if (spill && options) {
+        const artifactId =
+            options.requestEnvelope.artifact_ids?.[0] ?? DEFAULT_ACTIVITY_OUTPUT_ARTIFACT_ID;
+        const content = serializePayloadContent(payloadForStorage ?? '', outputType);
+        const relativePath = resolveActivityArtifactRelativePath(
+            options.requestEnvelope.workflow_run_id,
+            options.requestEnvelope.node_id,
+            artifactId,
+            outputType
+        );
+        const artifactRef = writeActivityArtifact(
+            options.workspaceRoot,
+            relativePath,
+            content,
+            artifactId,
+            outputType,
+            options.artifactWriter
+        );
+        response.artifact_refs = [artifactRef];
+    } else if (structuredPayload !== undefined) {
+        response.structured_payload = structuredPayload;
+    } else if (parsed !== undefined && followUpQuestions === undefined) {
+        response.structured_payload = parsed;
+    }
+
+    return finalizeActivityResponse(response);
 }

--- a/src/worker/validateActivityEnvelope.test.ts
+++ b/src/worker/validateActivityEnvelope.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { CursorSdkResponseEnvelope } from './activityEnvelope';
+import {
+    validateActivityEnvelope,
+    validateEnvelopeSchema,
+    validateEnvelopeUnsupportedVersion,
+    validateEnvelopeSize,
+    ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+    ENVELOPE_SIZE_EXCEEDED_CODE,
+    ENVELOPE_UNSUPPORTED_VERSION_CODE,
+    INLINE_STRUCTURED_PAYLOAD_MAX_BYTES,
+    TOTAL_ENVELOPE_MAX_BYTES,
+    resetActivityEnvelopeValidatorCacheForTests,
+} from './validateActivityEnvelope';
+
+function baseEnvelope(
+    overrides: Partial<CursorSdkResponseEnvelope> = {}
+): CursorSdkResponseEnvelope {
+    return {
+        envelope_version: '1.0.0',
+        activity_id: 'act-1',
+        node_id: 'node-1',
+        workflow_run_id: 'run-1',
+        cursor_agent_id: 'agent-1',
+        cursor_run_id: 'run-sdk-1',
+        output_type: 'json',
+        status: 'finished',
+        retryable: false,
+        ...overrides,
+    };
+}
+
+describe('validateActivityEnvelope', () => {
+    beforeEach(() => {
+        resetActivityEnvelopeValidatorCacheForTests();
+    });
+
+    it('accepts a finished envelope with json structured_payload', () => {
+        const envelope = baseEnvelope({
+            structured_payload: { summary: 'done', count: 2 },
+        });
+
+        const result = validateActivityEnvelope(envelope);
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('accepts finished envelopes for markdown and text output types', () => {
+        const markdown = baseEnvelope({
+            output_type: 'markdown',
+            structured_payload: '# Heading\n\nBody text.',
+        });
+        const text = baseEnvelope({
+            output_type: 'text',
+            structured_payload: 'plain output',
+        });
+
+        expect(validateActivityEnvelope(markdown).valid).toBe(true);
+        expect(validateActivityEnvelope(text).valid).toBe(true);
+    });
+
+    it('accepts an envelope with artifact_refs and no inline payload', () => {
+        const envelope = baseEnvelope({
+            artifact_refs: [
+                {
+                    artifact_id: 'refinement',
+                    path: '.ai/refinement.md',
+                    size_bytes: 1200,
+                    sha256: 'a'.repeat(64),
+                    media_type: 'text/markdown',
+                },
+            ],
+        });
+
+        const result = validateActivityEnvelope(envelope);
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('rejects error envelopes missing failure_class via schema validator', () => {
+        const envelope = baseEnvelope({
+            status: 'error',
+            retryable: true,
+        });
+
+        const result = validateEnvelopeSchema(envelope);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    severity: 'error',
+                    validator_id: ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('rejects unsupported envelope_version major via unsupported_version validator', () => {
+        const envelope = baseEnvelope({ envelope_version: '2.0.0' });
+
+        const result = validateEnvelopeUnsupportedVersion(envelope);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual([
+            expect.objectContaining({
+                code: ENVELOPE_UNSUPPORTED_VERSION_CODE,
+                path: '/envelope_version',
+                validator_id: ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+            }),
+        ]);
+    });
+
+    it('rejects oversize serialized envelopes via size validator', () => {
+        const oversizedPayload = 'x'.repeat(TOTAL_ENVELOPE_MAX_BYTES);
+        const envelope = baseEnvelope({
+            structured_payload: oversizedPayload,
+        });
+
+        const result = validateEnvelopeSize(envelope);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: ENVELOPE_SIZE_EXCEEDED_CODE,
+                    validator_id: ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('rejects inline structured_payload above 64 KiB', () => {
+        const envelope = baseEnvelope({
+            structured_payload: 'x'.repeat(INLINE_STRUCTURED_PAYLOAD_MAX_BYTES + 1),
+        });
+
+        const result = validateEnvelopeSize(envelope);
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: ENVELOPE_SIZE_EXCEEDED_CODE,
+                    path: '/structured_payload',
+                    validator_id: ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+                }),
+            ])
+        );
+    });
+
+    it('accepts cancelled envelopes with failure_class', () => {
+        const envelope = baseEnvelope({
+            status: 'cancelled',
+            failure_class: 'cancelled',
+            diagnostics: [
+                {
+                    code: 'cursor_sdk_cancelled',
+                    message: 'cancelled',
+                    severity: 'info',
+                    source: 'worker',
+                },
+            ],
+        });
+
+        expect(validateActivityEnvelope(envelope).valid).toBe(true);
+    });
+});

--- a/src/worker/validateActivityEnvelope.ts
+++ b/src/worker/validateActivityEnvelope.ts
@@ -1,0 +1,249 @@
+import fs from 'fs';
+import path from 'path';
+import Ajv2020, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';
+import {
+    type ActivityEnvelopeValidationResult,
+    type ActivityEnvelopeValidatorDiagnostic,
+} from './activityEnvelope';
+
+export const ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID = 'forge.envelope.schema';
+export const ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID = 'forge.envelope.unsupported_version';
+export const ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID = 'forge.envelope.size';
+
+export const INLINE_STRUCTURED_PAYLOAD_MAX_BYTES = 64 * 1024;
+export const TOTAL_ENVELOPE_MAX_BYTES = 256 * 1024;
+
+export const ENVELOPE_UNSUPPORTED_VERSION_CODE = 'forge.envelope.unsupported_version';
+export const ENVELOPE_SIZE_EXCEEDED_CODE = 'forge.envelope.size_exceeded';
+
+const SUPPORTED_ENVELOPE_VERSION_MAJOR = 1;
+
+const ACTIVITY_ENVELOPE_SCHEMA_RELATIVE_PATH = '.ai/schemas/activity-envelope.schema.json';
+
+let cachedValidator: ValidateFunction | undefined;
+
+function resolveActivityEnvelopeSchemaPath(): string {
+    const candidates = [
+        path.join(process.cwd(), ACTIVITY_ENVELOPE_SCHEMA_RELATIVE_PATH),
+        path.join(__dirname, '../../.ai/schemas/activity-envelope.schema.json'),
+    ];
+
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    throw new Error(`activity envelope schema not found (expected ${ACTIVITY_ENVELOPE_SCHEMA_RELATIVE_PATH})`);
+}
+
+function loadActivityEnvelopeSchemaValidator(): ValidateFunction {
+    if (cachedValidator) {
+        return cachedValidator;
+    }
+
+    const schemaPath = resolveActivityEnvelopeSchemaPath();
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as object;
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    cachedValidator = ajv.compile(schema);
+    return cachedValidator;
+}
+
+function parseSemverMajor(version: string): number | undefined {
+    const match = /^(\d+)\./.exec(version.trim());
+    if (!match) {
+        return undefined;
+    }
+    return Number.parseInt(match[1], 10);
+}
+
+function utf8ByteLength(value: string): number {
+    return Buffer.byteLength(value, 'utf8');
+}
+
+function diagnosticCodeForAjvError(error: ErrorObject): string {
+    const keyword = error.keyword;
+
+    switch (keyword) {
+        case 'required':
+            return 'schema.required';
+        case 'type':
+            return 'schema.type';
+        case 'enum':
+            return 'schema.enum';
+        case 'const':
+            return 'schema.const';
+        case 'additionalProperties':
+            return 'schema.additional_properties';
+        case 'minLength':
+        case 'minItems':
+        case 'pattern':
+            return 'schema.constraint';
+        default:
+            return `schema.${keyword}`;
+    }
+}
+
+function jsonPointerFromAjvError(error: ErrorObject): string {
+    const instancePath = error.instancePath || '';
+    if (instancePath.length > 0) {
+        return instancePath;
+    }
+
+    if (error.keyword === 'required' && error.params.missingProperty) {
+        return `/${String(error.params.missingProperty)}`;
+    }
+
+    return '/';
+}
+
+function messageForAjvError(error: ErrorObject): string {
+    if (error.message) {
+        return error.message;
+    }
+
+    return `JSON Schema validation failed (${error.keyword})`;
+}
+
+function mapAjvErrorToDiagnostic(error: ErrorObject): ActivityEnvelopeValidatorDiagnostic {
+    return {
+        code: diagnosticCodeForAjvError(error),
+        severity: 'error',
+        path: jsonPointerFromAjvError(error),
+        message: messageForAjvError(error),
+        source: 'validator',
+        validator_id: ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    };
+}
+
+function isEnvelopeRecord(content: unknown): content is Record<string, unknown> {
+    return content !== null && typeof content === 'object' && !Array.isArray(content);
+}
+
+function structuredPayloadUtf8Bytes(payload: unknown): number {
+    if (typeof payload === 'string') {
+        return utf8ByteLength(payload);
+    }
+
+    return utf8ByteLength(JSON.stringify(payload));
+}
+
+export function validateEnvelopeUnsupportedVersion(content: unknown): ActivityEnvelopeValidationResult {
+    if (!isEnvelopeRecord(content)) {
+        return { valid: true, diagnostics: [] };
+    }
+
+    const version = content.envelope_version;
+    if (typeof version !== 'string') {
+        return { valid: true, diagnostics: [] };
+    }
+
+    const major = parseSemverMajor(version);
+    if (major === undefined) {
+        return { valid: true, diagnostics: [] };
+    }
+
+    if (major !== SUPPORTED_ENVELOPE_VERSION_MAJOR) {
+        const diagnostic: ActivityEnvelopeValidatorDiagnostic = {
+            code: ENVELOPE_UNSUPPORTED_VERSION_CODE,
+            message: `envelope_version major ${major} is not supported (supported major: ${SUPPORTED_ENVELOPE_VERSION_MAJOR})`,
+            severity: 'error',
+            path: '/envelope_version',
+            source: 'validator',
+            validator_id: ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+        };
+
+        return { valid: false, diagnostics: [diagnostic] };
+    }
+
+    return { valid: true, diagnostics: [] };
+}
+
+export function validateEnvelopeSchema(content: unknown): ActivityEnvelopeValidationResult {
+    if (!isEnvelopeRecord(content)) {
+        const diagnostic: ActivityEnvelopeValidatorDiagnostic = {
+            code: 'schema.type',
+            severity: 'error',
+            path: '/',
+            message: 'activity envelope must be a JSON object',
+            source: 'validator',
+            validator_id: ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+        };
+
+        return { valid: false, diagnostics: [diagnostic] };
+    }
+
+    const validate = loadActivityEnvelopeSchemaValidator();
+    const valid = validate(content);
+
+    if (valid) {
+        return { valid: true, diagnostics: [] };
+    }
+
+    const diagnostics = (validate.errors ?? []).map(mapAjvErrorToDiagnostic);
+
+    return {
+        valid: false,
+        diagnostics,
+    };
+}
+
+export function validateEnvelopeSize(content: unknown): ActivityEnvelopeValidationResult {
+    if (!isEnvelopeRecord(content)) {
+        return { valid: true, diagnostics: [] };
+    }
+
+    const diagnostics: ActivityEnvelopeValidatorDiagnostic[] = [];
+
+    const structuredPayload = content.structured_payload;
+    if (structuredPayload !== undefined) {
+        const inlineBytes = structuredPayloadUtf8Bytes(structuredPayload);
+        if (inlineBytes > INLINE_STRUCTURED_PAYLOAD_MAX_BYTES) {
+            diagnostics.push({
+                code: ENVELOPE_SIZE_EXCEEDED_CODE,
+                message: `structured_payload exceeds inline limit (${inlineBytes} bytes; max ${INLINE_STRUCTURED_PAYLOAD_MAX_BYTES})`,
+                severity: 'error',
+                path: '/structured_payload',
+                source: 'validator',
+                validator_id: ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+            });
+        }
+    }
+
+    const totalBytes = utf8ByteLength(JSON.stringify(content));
+    if (totalBytes > TOTAL_ENVELOPE_MAX_BYTES) {
+        diagnostics.push({
+            code: ENVELOPE_SIZE_EXCEEDED_CODE,
+            message: `serialized envelope exceeds total limit (${totalBytes} bytes; max ${TOTAL_ENVELOPE_MAX_BYTES})`,
+            severity: 'error',
+            path: '/',
+            source: 'validator',
+            validator_id: ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+        });
+    }
+
+    return {
+        valid: diagnostics.length === 0,
+        diagnostics,
+    };
+}
+
+export function validateActivityEnvelope(content: unknown): ActivityEnvelopeValidationResult {
+    const versionResult = validateEnvelopeUnsupportedVersion(content);
+    const schemaResult = validateEnvelopeSchema(content);
+    const sizeResult = validateEnvelopeSize(content);
+
+    const diagnostics = [
+        ...versionResult.diagnostics,
+        ...schemaResult.diagnostics,
+        ...sizeResult.diagnostics,
+    ];
+
+    const valid = diagnostics.every((diagnostic) => diagnostic.severity !== 'error');
+
+    return { valid, diagnostics };
+}
+
+export function resetActivityEnvelopeValidatorCacheForTests(): void {
+    cachedValidator = undefined;
+}


### PR DESCRIPTION
## Description

Adds TypeScript types and AJV validation for v1 Cursor SDK activity envelopes (#48), and maps SDK `RunResult` outcomes to full contract-compliant response envelopes (#49): inline or artifact-spilled payloads, optional `follow_up_questions`, failure taxonomy fields, and pre-return size validation.

## Motivation and Context

Parent issue #23 tracks Cursor SDK envelope contracts for workflow activities. This PR delivers:

- **#48** — compile-time types and runtime validation against `.ai/schemas/activity-envelope.schema.json`
- **#49** — worker mapper that echoes correlation fields, spills outputs over 64 KiB (or when `artifact_ids` are declared) to repo artifacts with `artifact_refs`, extracts provisional `follow_up_questions`, and rejects total envelopes over 256 KiB with `forge.envelope.size_exceeded`

Closes #48
Closes #49

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] My changes generate no new warnings

## Additional Notes

- Artifact spill path: `.cursor/.tmp/forge-activities/{workflow_run_id}/{node_id}/{artifact_id}.{ext}`
- Output channel logs `artifact_refs` paths only (no payload or question prompt text)
- Validation helpers export `forge.envelope.schema`, `forge.envelope.unsupported_version`, and `forge.envelope.size` with diagnostic codes `forge.envelope.unsupported_version` and `forge.envelope.size_exceeded`