### PR TITLE
feat(validation): runtime validator registry and validation gate activity (#24)

### DIFF
--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -175,6 +175,14 @@ export type {
     TemporalRecoveryCoordinatorConfig,
 } from './temporalRecoveryCoordinator';
 export {
+    appendValidationSummary,
+    mapRuntimeValidationResultToSummary,
+} from './validationSummaryProjection';
+export type {
+    ValidationSummary,
+    ValidationSummaryValidatorOutcome,
+} from './validationSummaryProjection';
+export {
     buildProjectionFromTemporalDescribe,
     isTerminalTemporalStatus,
     readWorkflowRunProjection,

--- a/src/temporal/validationSummaryProjection.test.ts
+++ b/src/temporal/validationSummaryProjection.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+    appendValidationSummary,
+    mapRuntimeValidationResultToSummary,
+} from './validationSummaryProjection';
+import type { WorkflowRunProjection } from './workflowRunProjection';
+
+function baseProjection(): WorkflowRunProjection {
+    return {
+        namespace: 'forge-local',
+        workflowId: 'wf-1',
+        runId: 'run-1',
+        taskQueue: 'forge-workflows',
+        workflow_id: 'refine-issue',
+        repositoryRoot: '/repo',
+        mode: 'managedLocal',
+        recoveryState: 'synced',
+        lastSyncedAt: '2026-06-10T00:00:00.000Z',
+        terminal: false,
+        temporalStatus: 'RUNNING',
+        completedNodeIds: [],
+        skippedNodeIds: [],
+        cancelled: false,
+        validationSummaries: [],
+        pendingHumanQuestions: [],
+    };
+}
+
+describe('validationSummaryProjection', () => {
+    it('maps RuntimeValidationResult to ValidationSummary with redacted diagnostics', () => {
+        const summary = mapRuntimeValidationResultToSummary(
+            {
+                valid: false,
+                node_id: 'validate_triage_artifacts',
+                workflow_run_id: 'run-1',
+                source_activity_node_id: 'triage_questions',
+                validated_at: '2026-06-10T12:00:00.000Z',
+                diagnostics: [
+                    {
+                        code: 'forge.artifact.missing',
+                        severity: 'error',
+                        message: 'artifact user_questions not found',
+                        validator_id: 'forge.artifact.exists',
+                        path: 'user_questions',
+                    },
+                ],
+                validator_outcomes: [
+                    {
+                        validator_id: 'forge.artifact.exists',
+                        type: 'artifact',
+                        target: 'user_questions',
+                        passed: false,
+                        blocking: true,
+                        diagnostics: [
+                            {
+                                code: 'forge.artifact.missing',
+                                severity: 'error',
+                                message: 'artifact user_questions not found',
+                                validator_id: 'forge.artifact.exists',
+                                path: 'user_questions',
+                            },
+                        ],
+                    },
+                ],
+            },
+            'Validate triage artifacts'
+        );
+
+        expect(summary.node_name).toBe('Validate triage artifacts');
+        expect(summary.valid).toBe(false);
+        expect(summary.source_activity_node_id).toBe('triage_questions');
+        expect(summary.validator_outcomes).toEqual([
+            {
+                validator_id: 'forge.artifact.exists',
+                type: 'artifact',
+                target: 'user_questions',
+                passed: false,
+                blocking: true,
+            },
+        ]);
+        expect(summary.diagnostics).toEqual([
+            {
+                code: 'forge.artifact.missing',
+                severity: 'error',
+                message: 'artifact user_questions not found',
+                validator_id: 'forge.artifact.exists',
+                path: 'user_questions',
+            },
+        ]);
+    });
+
+    it('appends validation summaries and sets failedNodeId on validation failure', () => {
+        const summary = mapRuntimeValidationResultToSummary(
+            {
+                valid: false,
+                node_id: 'validate_exit_criteria',
+                workflow_run_id: 'run-1',
+                validated_at: '2026-06-10T12:00:00.000Z',
+                diagnostics: [],
+                validator_outcomes: [],
+            },
+            'Validate refine-issue exit criteria'
+        );
+
+        const updated = appendValidationSummary(baseProjection(), summary);
+
+        expect(updated.validationSummaries).toHaveLength(1);
+        expect(updated.validationSummaries[0]?.node_id).toBe('validate_exit_criteria');
+        expect(updated.failedNodeId).toBe('validate_exit_criteria');
+    });
+
+    it('does not set failedNodeId when validation passes', () => {
+        const summary = mapRuntimeValidationResultToSummary(
+            {
+                valid: true,
+                node_id: 'validate_triage_artifacts',
+                workflow_run_id: 'run-1',
+                validated_at: '2026-06-10T12:00:00.000Z',
+                diagnostics: [],
+                validator_outcomes: [],
+            },
+            'Validate triage artifacts'
+        );
+
+        const updated = appendValidationSummary(baseProjection(), summary);
+
+        expect(updated.validationSummaries).toHaveLength(1);
+        expect(updated.failedNodeId).toBeUndefined();
+    });
+});

--- a/src/temporal/validationSummaryProjection.ts
+++ b/src/temporal/validationSummaryProjection.ts
@@ -1,0 +1,75 @@
+import type {
+    RuntimeValidationDiagnostic,
+    RuntimeValidationResult,
+    RuntimeValidatorType,
+} from '../validation';
+import type { WorkflowRunProjection } from './workflowRunProjection';
+
+export interface ValidationSummaryValidatorOutcome {
+    validator_id: string;
+    type: RuntimeValidatorType;
+    target?: string;
+    passed: boolean;
+    blocking: boolean;
+}
+
+export interface ValidationSummary {
+    node_id: string;
+    node_name: string;
+    valid: boolean;
+    validated_at: string;
+    source_activity_node_id?: string;
+    validator_outcomes: ValidationSummaryValidatorOutcome[];
+    diagnostics: RuntimeValidationDiagnostic[];
+}
+
+export function mapRuntimeValidationResultToSummary(
+    result: RuntimeValidationResult,
+    nodeName: string
+): ValidationSummary {
+    return {
+        node_id: result.node_id,
+        node_name: nodeName,
+        valid: result.valid,
+        validated_at: result.validated_at,
+        ...(result.source_activity_node_id
+            ? { source_activity_node_id: result.source_activity_node_id }
+            : {}),
+        validator_outcomes: result.validator_outcomes.map((outcome) => ({
+            validator_id: outcome.validator_id,
+            type: outcome.type,
+            ...(outcome.target ? { target: outcome.target } : {}),
+            passed: outcome.passed,
+            blocking: outcome.blocking,
+        })),
+        diagnostics: result.diagnostics.map(redactValidationDiagnostic),
+    };
+}
+
+function redactValidationDiagnostic(
+    diagnostic: RuntimeValidationDiagnostic
+): RuntimeValidationDiagnostic {
+    return {
+        code: diagnostic.code,
+        severity: diagnostic.severity,
+        message: diagnostic.message,
+        validator_id: diagnostic.validator_id,
+        ...(diagnostic.path ? { path: diagnostic.path } : {}),
+    };
+}
+
+export function appendValidationSummary(
+    projection: WorkflowRunProjection,
+    summary: ValidationSummary
+): WorkflowRunProjection {
+    return {
+        ...projection,
+        validationSummaries: [...projection.validationSummaries, summary],
+        ...(summary.valid
+            ? {}
+            : {
+                  failedNodeId: summary.node_id,
+                  validatingNodeId: undefined,
+              }),
+    };
+}

--- a/src/temporal/workflowRunProjection.ts
+++ b/src/temporal/workflowRunProjection.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import type { WorkflowExecutionDescription } from '@temporalio/client';
 import type { TemporalMode } from './temporalSettings';
 import type { RecoveryState, WorkflowRunIndexEntry } from './workflowRunIndex';
+import type { ValidationSummary } from './validationSummaryProjection';
 
 export type WorkflowExecutionStatusName =
     | 'UNSPECIFIED'
@@ -37,7 +38,10 @@ export interface WorkflowRunProjection {
     completedNodeIds: string[];
     skippedNodeIds: string[];
     cancelled: boolean;
-    validationSummaries: [];
+    activeNodeId?: string;
+    failedNodeId?: string;
+    validatingNodeId?: string;
+    validationSummaries: ValidationSummary[];
     pendingHumanQuestions: PendingHumanQuestion[];
 }
 

--- a/src/validation/artifactPathResolution.test.ts
+++ b/src/validation/artifactPathResolution.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { globPatternToRegExp, resolveArtifactGlobPaths } from './artifactPathResolution';
+
+const tempDirs: string[] = [];
+
+function createTempWorkspace(): string {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-artifact-glob-'));
+    tempDirs.push(workspaceRoot);
+    return workspaceRoot;
+}
+
+afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+describe('artifactPathResolution', () => {
+    it('matches refine-issue tmp artifact glob paths', () => {
+        const workspaceRoot = createTempWorkspace();
+        const sessionDir = path.join(workspaceRoot, '.cursor', '.tmp', 'refine-forge-50');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'user_questions.md'), '# Questions');
+        fs.writeFileSync(path.join(sessionDir, 'assumptions.md'), '# Assumptions');
+
+        const matches = resolveArtifactGlobPaths(
+            workspaceRoot,
+            '.cursor/.tmp/refine-*/user_questions.md'
+        );
+
+        expect(matches).toEqual(['.cursor/.tmp/refine-forge-50/user_questions.md']);
+    });
+
+    it('returns empty array when glob pattern has no matches', () => {
+        const workspaceRoot = createTempWorkspace();
+
+        const matches = resolveArtifactGlobPaths(
+            workspaceRoot,
+            '.cursor/.tmp/refine-*/user_questions.md'
+        );
+
+        expect(matches).toEqual([]);
+    });
+
+    it('returns literal path when pattern has no wildcard', () => {
+        const workspaceRoot = createTempWorkspace();
+        const filePath = path.join(workspaceRoot, 'artifacts', 'output.json');
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, '{}');
+
+        const matches = resolveArtifactGlobPaths(workspaceRoot, 'artifacts/output.json');
+
+        expect(matches).toEqual(['artifacts/output.json']);
+    });
+
+    it('converts glob patterns to anchored regular expressions', () => {
+        expect(globPatternToRegExp('.cursor/.tmp/refine-*/user_questions.md').test(
+            '.cursor/.tmp/refine-forge-50/user_questions.md'
+        )).toBe(true);
+        expect(globPatternToRegExp('.cursor/.tmp/refine-*/user_questions.md').test(
+            '.cursor/.tmp/other/user_questions.md'
+        )).toBe(false);
+    });
+});

--- a/src/validation/artifactPathResolution.ts
+++ b/src/validation/artifactPathResolution.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+
+function escapeRegexSegment(segment: string): string {
+    return segment.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function globPatternToRegExp(globPattern: string): RegExp {
+    const normalized = globPattern.split(path.sep).join('/');
+    const regexSource = normalized
+        .split('*')
+        .map((segment) => escapeRegexSegment(segment))
+        .join('[^/]*');
+    return new RegExp(`^${regexSource}$`);
+}
+
+function listRelativeFilesRecursive(absoluteDir: string, relativePrefix: string): string[] {
+    if (!fs.existsSync(absoluteDir)) {
+        return [];
+    }
+
+    const results: string[] = [];
+
+    for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+        const relativePath = relativePrefix.length > 0 ? `${relativePrefix}/${entry.name}` : entry.name;
+
+        if (entry.isDirectory()) {
+            results.push(...listRelativeFilesRecursive(path.join(absoluteDir, entry.name), relativePath));
+            continue;
+        }
+
+        if (entry.isFile()) {
+            results.push(relativePath.split(path.sep).join('/'));
+        }
+    }
+
+    return results;
+}
+
+export function resolveArtifactGlobPaths(workspaceRoot: string, pattern: string): string[] {
+    const normalizedPattern = pattern.split(path.sep).join('/');
+
+    if (!normalizedPattern.includes('*')) {
+        const absolutePath = path.join(workspaceRoot, normalizedPattern);
+        return fs.existsSync(absolutePath) ? [normalizedPattern] : [];
+    }
+
+    const matcher = globPatternToRegExp(normalizedPattern);
+    const allRelativeFiles = listRelativeFilesRecursive(workspaceRoot, '');
+
+    return allRelativeFiles.filter((relativePath) => matcher.test(relativePath)).sort();
+}
+
+export function findWorkflowArtifactPath(
+    workflowArtifacts: Array<{ artifact_id: string; path: string }> | undefined,
+    artifactId: string
+): string | undefined {
+    return workflowArtifacts?.find((artifact) => artifact.artifact_id === artifactId)?.path;
+}

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,57 @@
+export type {
+    DomainExitCriteriaContext,
+    RefineIssueExitCriteriaContext,
+    RuntimeValidationDiagnostic,
+    RuntimeValidationResult,
+    RuntimeValidatorOutcome,
+    RuntimeValidatorType,
+    ValidationNodeValidator,
+    ValidatorExecutor,
+    ValidatorExecutorContext,
+    ValidatorExecutorResult,
+    WorkflowArtifactDefinition,
+} from './types';
+
+export {
+    globPatternToRegExp,
+    findWorkflowArtifactPath,
+    resolveArtifactGlobPaths,
+} from './artifactPathResolution';
+
+export {
+    validateJsonSchemaContent,
+    validateRuntimeValidationResultSchema,
+    resetJsonSchemaValidatorCacheForTests,
+} from './jsonSchemaValidation';
+
+export {
+    ARTIFACT_EXISTS_VALIDATOR_ID,
+    ARTIFACT_INTEGRITY_VALIDATOR_ID,
+    ARTIFACT_SCHEMA_VALIDATOR_ID,
+    DOMAIN_EXIT_CRITERIA_VALIDATOR_ID,
+    REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID,
+    executeArtifactExistsValidator,
+    executeArtifactIntegrityValidator,
+    executeArtifactSchemaValidator,
+    executeDomainExitCriteriaValidator,
+    executeEnvelopeSchemaValidator,
+    executeEnvelopeSizeValidator,
+    executeEnvelopeUnsupportedVersionValidator,
+    executeRefineIssueExitCriteriaValidator,
+} from './validators';
+
+export {
+    RUNTIME_CATALOG_VALIDATOR_IDS,
+    assembleRuntimeValidationResult,
+    executeRegisteredValidator,
+    getValidatorExecutor,
+    isRuntimeCatalogValidatorId,
+} from './validatorRegistry';
+
+export type { RuntimeCatalogValidatorId } from './validatorRegistry';
+
+export {
+    ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+} from '../worker/validateActivityEnvelope';

--- a/src/validation/jsonSchemaValidation.ts
+++ b/src/validation/jsonSchemaValidation.ts
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import path from 'path';
+import Ajv2020, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';
+import type { RuntimeValidationDiagnostic } from './types';
+
+const schemaValidatorCache = new Map<string, ValidateFunction>();
+
+function resolveSchemaPath(schemaRelativePath: string): string {
+    const normalized = schemaRelativePath.replace(/\\/g, '/');
+    const candidates = [
+        path.join(process.cwd(), normalized),
+        path.join(__dirname, '../../', normalized),
+    ];
+
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    throw new Error(`JSON Schema not found (expected ${normalized})`);
+}
+
+function loadSchemaValidator(schemaRelativePath: string): ValidateFunction {
+    const cached = schemaValidatorCache.get(schemaRelativePath);
+    if (cached) {
+        return cached;
+    }
+
+    const schemaPath = resolveSchemaPath(schemaRelativePath);
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as object;
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    const validator = ajv.compile(schema);
+    schemaValidatorCache.set(schemaRelativePath, validator);
+    return validator;
+}
+
+function diagnosticCodeForAjvError(error: ErrorObject): string {
+    switch (error.keyword) {
+        case 'required':
+            return 'schema.required';
+        case 'type':
+            return 'schema.type';
+        case 'enum':
+            return 'schema.enum';
+        case 'const':
+            return 'schema.const';
+        case 'additionalProperties':
+            return 'schema.additional_properties';
+        case 'minLength':
+        case 'minItems':
+        case 'pattern':
+            return 'schema.constraint';
+        default:
+            return `schema.${error.keyword}`;
+    }
+}
+
+function jsonPointerFromAjvError(error: ErrorObject): string {
+    const instancePath = error.instancePath || '';
+    if (instancePath.length > 0) {
+        return instancePath;
+    }
+
+    if (error.keyword === 'required' && error.params.missingProperty) {
+        return `/${String(error.params.missingProperty)}`;
+    }
+
+    return '/';
+}
+
+function mapAjvErrorToDiagnostic(
+    error: ErrorObject,
+    validatorId: string
+): RuntimeValidationDiagnostic {
+    return {
+        code: diagnosticCodeForAjvError(error),
+        severity: 'error',
+        path: jsonPointerFromAjvError(error),
+        message: error.message ?? `JSON Schema validation failed (${error.keyword})`,
+        validator_id: validatorId,
+    };
+}
+
+export interface JsonSchemaValidationOptions {
+    schemaRelativePath: string;
+    validatorId: string;
+}
+
+export function validateJsonSchemaContent(
+    content: unknown,
+    options: JsonSchemaValidationOptions
+): { valid: boolean; diagnostics: RuntimeValidationDiagnostic[] } {
+    if (content === null || typeof content !== 'object' || Array.isArray(content)) {
+        return {
+            valid: false,
+            diagnostics: [
+                {
+                    code: 'schema.type',
+                    severity: 'error',
+                    path: '/',
+                    message: 'content must be a JSON object',
+                    validator_id: options.validatorId,
+                },
+            ],
+        };
+    }
+
+    const validate = loadSchemaValidator(options.schemaRelativePath);
+    const valid = validate(content);
+
+    if (valid) {
+        return { valid: true, diagnostics: [] };
+    }
+
+    return {
+        valid: false,
+        diagnostics: (validate.errors ?? []).map((error) =>
+            mapAjvErrorToDiagnostic(error, options.validatorId)
+        ),
+    };
+}
+
+export function validateRuntimeValidationResultSchema(
+    result: unknown
+): { valid: boolean; diagnostics: RuntimeValidationDiagnostic[] } {
+    return validateJsonSchemaContent(result, {
+        schemaRelativePath: '.ai/schemas/validation-result.schema.json',
+        validatorId: 'forge.validation_result.schema',
+    });
+}
+
+export function resetJsonSchemaValidatorCacheForTests(): void {
+    schemaValidatorCache.clear();
+}

--- a/src/validation/runtimeValidation.test.ts
+++ b/src/validation/runtimeValidation.test.ts
@@ -1,0 +1,360 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { CursorSdkResponseEnvelope } from '../worker/activityEnvelope';
+import { resetActivityEnvelopeValidatorCacheForTests } from '../worker/validateActivityEnvelope';
+import { resetJsonSchemaValidatorCacheForTests } from './jsonSchemaValidation';
+import {
+    assembleRuntimeValidationResult,
+    executeRegisteredValidator,
+    getValidatorExecutor,
+    isRuntimeCatalogValidatorId,
+    RUNTIME_CATALOG_VALIDATOR_IDS,
+} from './validatorRegistry';
+import { validateRuntimeValidationResultSchema } from './jsonSchemaValidation';
+import {
+    ARTIFACT_EXISTS_VALIDATOR_ID,
+    ARTIFACT_INTEGRITY_VALIDATOR_ID,
+    executeArtifactExistsValidator,
+    executeArtifactIntegrityValidator,
+    executeDomainExitCriteriaValidator,
+    executeEnvelopeSchemaValidator,
+    executeRefineIssueExitCriteriaValidator,
+} from './validators';
+import type { ValidatorExecutorContext, WorkflowArtifactDefinition } from './types';
+
+const tempDirs: string[] = [];
+
+function createTempWorkspace(): string {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-runtime-validation-'));
+    tempDirs.push(workspaceRoot);
+    return workspaceRoot;
+}
+
+function baseEnvelope(overrides: Partial<CursorSdkResponseEnvelope> = {}): CursorSdkResponseEnvelope {
+    return {
+        envelope_version: '1.0.0',
+        activity_id: 'act-1',
+        node_id: 'node-1',
+        workflow_run_id: 'run-1',
+        cursor_agent_id: 'agent-1',
+        cursor_run_id: 'run-sdk-1',
+        output_type: 'json',
+        status: 'finished',
+        retryable: false,
+        ...overrides,
+    };
+}
+
+const refineIssueArtifacts: WorkflowArtifactDefinition[] = [
+    {
+        artifact_id: 'user_questions',
+        path: '.cursor/.tmp/refine-*/user_questions.md',
+    },
+    {
+        artifact_id: 'assumptions',
+        path: '.cursor/.tmp/refine-*/assumptions.md',
+    },
+];
+
+afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+describe('runtime validation registry', () => {
+    beforeEach(() => {
+        resetActivityEnvelopeValidatorCacheForTests();
+        resetJsonSchemaValidatorCacheForTests();
+    });
+
+    it('registers all v1 runtime catalog validator ids', () => {
+        expect(RUNTIME_CATALOG_VALIDATOR_IDS).toEqual([
+            'forge.envelope.schema',
+            'forge.envelope.unsupported_version',
+            'forge.envelope.size',
+            'forge.artifact.exists',
+            'forge.artifact.integrity',
+            'forge.artifact.schema',
+            'forge.domain.exit_criteria',
+            'local.forge.refine_issue.exit_criteria',
+        ]);
+
+        for (const validatorId of RUNTIME_CATALOG_VALIDATOR_IDS) {
+            expect(isRuntimeCatalogValidatorId(validatorId)).toBe(true);
+            expect(getValidatorExecutor(validatorId)).toBeTypeOf('function');
+        }
+    });
+
+    it('passes envelope schema validation for a valid envelope', () => {
+        const result = executeEnvelopeSchemaValidator(
+            { validator_id: 'forge.envelope.schema', type: 'schema' },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                envelope: baseEnvelope({ structured_payload: { ok: true } }),
+            }
+        );
+
+        expect(result.passed).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('fails envelope schema validation for unsupported envelope versions', () => {
+        const result = executeRegisteredValidator(
+            { validator_id: 'forge.envelope.unsupported_version', type: 'domain' },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                envelope: baseEnvelope({ envelope_version: '2.0.0' }),
+            }
+        );
+
+        expect(result.passed).toBe(false);
+        expect(result.diagnostics?.[0]?.validator_id).toBe('forge.envelope.unsupported_version');
+    });
+
+    it('passes artifact exists validation when refine glob artifacts are present', () => {
+        const workspaceRoot = createTempWorkspace();
+        const sessionDir = path.join(workspaceRoot, '.cursor', '.tmp', 'refine-forge-50');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'user_questions.md'), '# Questions');
+
+        const context: ValidatorExecutorContext = {
+            workspaceRoot,
+            workflowRunId: 'run-1',
+            nodeId: 'validate_triage_artifacts',
+            workflowArtifacts: refineIssueArtifacts,
+        };
+
+        const result = executeArtifactExistsValidator(
+            {
+                validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                type: 'artifact',
+                target: 'user_questions',
+            },
+            context
+        );
+
+        expect(result.passed).toBe(true);
+    });
+
+    it('fails artifact exists validation when refine glob artifacts are missing', () => {
+        const result = executeArtifactExistsValidator(
+            {
+                validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                type: 'artifact',
+                target: 'user_questions',
+            },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate_triage_artifacts',
+                workflowArtifacts: refineIssueArtifacts,
+            }
+        );
+
+        expect(result.passed).toBe(false);
+        expect(result.diagnostics[0]?.code).toBe('forge.artifact.not_found');
+    });
+
+    it('detects SHA-256 mismatch in artifact integrity validation', () => {
+        const workspaceRoot = createTempWorkspace();
+        const relativePath = '.cursor/.tmp/refine-forge-50/user_questions.md';
+        const absolutePath = path.join(workspaceRoot, relativePath);
+        fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+        fs.writeFileSync(absolutePath, '# Questions');
+
+        const actualHash = crypto.createHash('sha256').update('# Questions', 'utf8').digest('hex');
+
+        const mismatchResult = executeArtifactIntegrityValidator(
+            { validator_id: ARTIFACT_INTEGRITY_VALIDATOR_ID, type: 'artifact' },
+            {
+                workspaceRoot,
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                envelope: baseEnvelope({
+                    artifact_refs: [
+                        {
+                            artifact_id: 'user_questions',
+                            path: relativePath,
+                            size_bytes: 11,
+                            sha256: 'f'.repeat(64),
+                        },
+                    ],
+                }),
+            }
+        );
+
+        expect(mismatchResult.passed).toBe(false);
+        expect(mismatchResult.diagnostics[0]?.code).toBe('forge.artifact.integrity.mismatch');
+
+        const passResult = executeArtifactIntegrityValidator(
+            { validator_id: ARTIFACT_INTEGRITY_VALIDATOR_ID, type: 'artifact' },
+            {
+                workspaceRoot,
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                envelope: baseEnvelope({
+                    artifact_refs: [
+                        {
+                            artifact_id: 'user_questions',
+                            path: relativePath,
+                            size_bytes: 11,
+                            sha256: actualHash,
+                        },
+                    ],
+                }),
+            }
+        );
+
+        expect(passResult.passed).toBe(true);
+    });
+
+    it('skips missing files in integrity validation so exists validators surface them first', () => {
+        const result = executeArtifactIntegrityValidator(
+            { validator_id: ARTIFACT_INTEGRITY_VALIDATOR_ID, type: 'artifact' },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                envelope: baseEnvelope({
+                    artifact_refs: [
+                        {
+                            artifact_id: 'user_questions',
+                            path: '.cursor/.tmp/refine-forge-50/user_questions.md',
+                            size_bytes: 11,
+                            sha256: 'a'.repeat(64),
+                        },
+                    ],
+                }),
+            }
+        );
+
+        expect(result.passed).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('evaluates generic and refine-issue domain exit criteria validators', () => {
+        const genericFail = executeDomainExitCriteriaValidator(
+            {
+                validator_id: 'forge.domain.exit_criteria',
+                type: 'domain',
+                target: 'criteria_a',
+            },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                domainExitCriteria: { criteriaMet: { criteria_a: false } },
+            }
+        );
+        expect(genericFail.passed).toBe(false);
+
+        const genericPass = executeDomainExitCriteriaValidator(
+            {
+                validator_id: 'forge.domain.exit_criteria',
+                type: 'domain',
+                target: 'criteria_a',
+            },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate-node',
+                domainExitCriteria: { criteriaMet: { criteria_a: true } },
+            }
+        );
+        expect(genericPass.passed).toBe(true);
+
+        const refineFail = executeRefineIssueExitCriteriaValidator(
+            { validator_id: 'local.forge.refine_issue.exit_criteria', type: 'domain' },
+            {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-1',
+                nodeId: 'validate_exit_criteria',
+                refineIssueExitContext: {
+                    issueBodyValid: true,
+                    blockersResolved: false,
+                    openDecisionsResolved: true,
+                    aiChangesCommitted: true,
+                },
+            }
+        );
+        expect(refineFail.passed).toBe(false);
+        expect(refineFail.diagnostics.some((diagnostic) => diagnostic.path === 'blockersResolved')).toBe(
+            true
+        );
+    });
+
+    it('assembles aggregate ValidationResult output that matches JSON Schema', () => {
+        const workspaceRoot = createTempWorkspace();
+        const sessionDir = path.join(workspaceRoot, '.cursor', '.tmp', 'refine-forge-50');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'user_questions.md'), '# Questions');
+        fs.writeFileSync(path.join(sessionDir, 'assumptions.md'), '# Assumptions');
+
+        const aggregate = assembleRuntimeValidationResult({
+            nodeId: 'validate_triage_artifacts',
+            workflowRunId: 'run-123',
+            sourceActivityNodeId: 'triage_questions',
+            validators: [
+                {
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    type: 'artifact',
+                    target: 'user_questions',
+                },
+                {
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    type: 'artifact',
+                    target: 'assumptions',
+                },
+            ],
+            context: {
+                workspaceRoot,
+                workflowRunId: 'run-123',
+                nodeId: 'validate_triage_artifacts',
+                sourceActivityNodeId: 'triage_questions',
+                workflowArtifacts: refineIssueArtifacts,
+            },
+            validatedAt: '2026-06-10T12:00:00.000Z',
+        });
+
+        expect(aggregate.valid).toBe(true);
+        expect(aggregate.validator_outcomes).toHaveLength(2);
+        expect(aggregate.diagnostics).toEqual([]);
+
+        const schemaValidation = validateRuntimeValidationResultSchema(aggregate);
+        expect(schemaValidation.valid).toBe(true);
+    });
+
+    it('assembles failed aggregate with ordered diagnostics and validator outcomes', () => {
+        const aggregate = assembleRuntimeValidationResult({
+            nodeId: 'validate_triage_artifacts',
+            workflowRunId: 'run-123',
+            validators: [
+                {
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    type: 'artifact',
+                    target: 'user_questions',
+                },
+            ],
+            context: {
+                workspaceRoot: createTempWorkspace(),
+                workflowRunId: 'run-123',
+                nodeId: 'validate_triage_artifacts',
+                workflowArtifacts: refineIssueArtifacts,
+            },
+            validatedAt: '2026-06-10T12:00:00.000Z',
+        });
+
+        expect(aggregate.valid).toBe(false);
+        expect(aggregate.validator_outcomes[0]?.passed).toBe(false);
+        expect(aggregate.diagnostics).toHaveLength(1);
+        expect(validateRuntimeValidationResultSchema(aggregate).valid).toBe(true);
+    });
+});

--- a/src/validation/types.ts
+++ b/src/validation/types.ts
@@ -1,0 +1,76 @@
+import type { CursorSdkResponseEnvelope } from '../worker/activityEnvelope';
+
+export type RuntimeDiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface RuntimeValidationDiagnostic {
+    code: string;
+    severity: RuntimeDiagnosticSeverity;
+    message: string;
+    validator_id: string;
+    path?: string;
+}
+
+export type RuntimeValidatorType = 'schema' | 'artifact' | 'domain';
+
+export interface RuntimeValidatorOutcome {
+    validator_id: string;
+    type: RuntimeValidatorType;
+    target?: string;
+    passed: boolean;
+    blocking: boolean;
+    diagnostics?: RuntimeValidationDiagnostic[];
+}
+
+export interface RuntimeValidationResult {
+    valid: boolean;
+    node_id: string;
+    workflow_run_id: string;
+    source_activity_node_id?: string;
+    validated_at: string;
+    diagnostics: RuntimeValidationDiagnostic[];
+    validator_outcomes: RuntimeValidatorOutcome[];
+}
+
+export interface WorkflowArtifactDefinition {
+    artifact_id: string;
+    path: string;
+    description?: string;
+}
+
+export interface ValidationNodeValidator {
+    validator_id: string;
+    type: RuntimeValidatorType;
+    target?: string;
+}
+
+export interface DomainExitCriteriaContext {
+    criteriaMet: Record<string, boolean>;
+}
+
+export interface RefineIssueExitCriteriaContext {
+    issueBodyValid: boolean;
+    blockersResolved: boolean;
+    openDecisionsResolved: boolean;
+    aiChangesCommitted: boolean;
+}
+
+export interface ValidatorExecutorContext {
+    workspaceRoot: string;
+    workflowRunId: string;
+    nodeId: string;
+    sourceActivityNodeId?: string;
+    envelope?: CursorSdkResponseEnvelope;
+    workflowArtifacts?: WorkflowArtifactDefinition[];
+    domainExitCriteria?: DomainExitCriteriaContext;
+    refineIssueExitContext?: RefineIssueExitCriteriaContext;
+}
+
+export interface ValidatorExecutorResult {
+    passed: boolean;
+    diagnostics: RuntimeValidationDiagnostic[];
+}
+
+export type ValidatorExecutor = (
+    declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+) => ValidatorExecutorResult;

--- a/src/validation/validatorRegistry.ts
+++ b/src/validation/validatorRegistry.ts
@@ -1,0 +1,155 @@
+import {
+    ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+} from '../worker/validateActivityEnvelope';
+import type {
+    RuntimeValidatorOutcome,
+    RuntimeValidatorType,
+    RuntimeValidationDiagnostic,
+    RuntimeValidationResult,
+    ValidationNodeValidator,
+    ValidatorExecutor,
+    ValidatorExecutorContext,
+} from './types';
+import {
+    ARTIFACT_EXISTS_VALIDATOR_ID,
+    ARTIFACT_INTEGRITY_VALIDATOR_ID,
+    ARTIFACT_SCHEMA_VALIDATOR_ID,
+    DOMAIN_EXIT_CRITERIA_VALIDATOR_ID,
+    REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID,
+    executeArtifactExistsValidator,
+    executeArtifactIntegrityValidator,
+    executeArtifactSchemaValidator,
+    executeDomainExitCriteriaValidator,
+    executeEnvelopeSchemaValidator,
+    executeEnvelopeSizeValidator,
+    executeEnvelopeUnsupportedVersionValidator,
+    executeRefineIssueExitCriteriaValidator,
+} from './validators';
+
+export const RUNTIME_CATALOG_VALIDATOR_IDS = [
+    ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+    ARTIFACT_EXISTS_VALIDATOR_ID,
+    ARTIFACT_INTEGRITY_VALIDATOR_ID,
+    ARTIFACT_SCHEMA_VALIDATOR_ID,
+    DOMAIN_EXIT_CRITERIA_VALIDATOR_ID,
+    REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID,
+] as const;
+
+export type RuntimeCatalogValidatorId = (typeof RUNTIME_CATALOG_VALIDATOR_IDS)[number];
+
+const VALIDATOR_EXECUTORS: Record<string, ValidatorExecutor> = {
+    [ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID]: executeEnvelopeSchemaValidator,
+    [ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID]: executeEnvelopeUnsupportedVersionValidator,
+    [ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID]: executeEnvelopeSizeValidator,
+    [ARTIFACT_EXISTS_VALIDATOR_ID]: executeArtifactExistsValidator,
+    [ARTIFACT_INTEGRITY_VALIDATOR_ID]: executeArtifactIntegrityValidator,
+    [ARTIFACT_SCHEMA_VALIDATOR_ID]: executeArtifactSchemaValidator,
+    [DOMAIN_EXIT_CRITERIA_VALIDATOR_ID]: executeDomainExitCriteriaValidator,
+    [REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID]: executeRefineIssueExitCriteriaValidator,
+};
+
+export function isRuntimeCatalogValidatorId(validatorId: string): validatorId is RuntimeCatalogValidatorId {
+    return (RUNTIME_CATALOG_VALIDATOR_IDS as readonly string[]).includes(validatorId);
+}
+
+export function getValidatorExecutor(validatorId: string): ValidatorExecutor | undefined {
+    return VALIDATOR_EXECUTORS[validatorId];
+}
+
+export function assembleRuntimeValidationResult(input: {
+    nodeId: string;
+    workflowRunId: string;
+    sourceActivityNodeId?: string;
+    validators: ValidationNodeValidator[];
+    context: ValidatorExecutorContext;
+    validatedAt?: string;
+}): RuntimeValidationResult {
+    const validatorOutcomes: RuntimeValidatorOutcome[] = [];
+    const diagnostics: RuntimeValidationDiagnostic[] = [];
+
+    for (const declaration of input.validators) {
+        const executor = getValidatorExecutor(declaration.validator_id);
+        if (!executor) {
+            const outcome: RuntimeValidatorOutcome = {
+                validator_id: declaration.validator_id,
+                type: declaration.type,
+                target: declaration.target,
+                passed: false,
+                blocking: true,
+                diagnostics: [
+                    {
+                        code: 'forge.validator.unregistered',
+                        severity: 'error',
+                        message: `no executor registered for validator "${declaration.validator_id}"`,
+                        validator_id: declaration.validator_id,
+                    },
+                ],
+            };
+            validatorOutcomes.push(outcome);
+            diagnostics.push(...(outcome.diagnostics ?? []));
+            continue;
+        }
+
+        const result = executor(declaration, input.context);
+        const outcome: RuntimeValidatorOutcome = {
+            validator_id: declaration.validator_id,
+            type: declaration.type,
+            target: declaration.target,
+            passed: result.passed,
+            blocking: true,
+            ...(result.diagnostics.length > 0 ? { diagnostics: result.diagnostics } : {}),
+        };
+        validatorOutcomes.push(outcome);
+        diagnostics.push(...result.diagnostics);
+    }
+
+    const valid = validatorOutcomes.every((outcome) => outcome.passed || !outcome.blocking);
+
+    return {
+        valid,
+        node_id: input.nodeId,
+        workflow_run_id: input.workflowRunId,
+        ...(input.sourceActivityNodeId ? { source_activity_node_id: input.sourceActivityNodeId } : {}),
+        validated_at: input.validatedAt ?? new Date().toISOString(),
+        diagnostics,
+        validator_outcomes: validatorOutcomes,
+    };
+}
+
+export function executeRegisteredValidator(
+    declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): RuntimeValidatorOutcome {
+    const executor = getValidatorExecutor(declaration.validator_id);
+    if (!executor) {
+        return {
+            validator_id: declaration.validator_id,
+            type: declaration.type,
+            target: declaration.target,
+            passed: false,
+            blocking: true,
+            diagnostics: [
+                {
+                    code: 'forge.validator.unregistered',
+                    severity: 'error',
+                    message: `no executor registered for validator "${declaration.validator_id}"`,
+                    validator_id: declaration.validator_id,
+                },
+            ],
+        };
+    }
+
+    const result = executor(declaration, context);
+    return {
+        validator_id: declaration.validator_id,
+        type: declaration.type as RuntimeValidatorType,
+        target: declaration.target,
+        passed: result.passed,
+        blocking: true,
+        ...(result.diagnostics.length > 0 ? { diagnostics: result.diagnostics } : {}),
+    };
+}

--- a/src/validation/validators.ts
+++ b/src/validation/validators.ts
@@ -1,0 +1,389 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import type { CursorSdkResponseEnvelope } from '../worker/activityEnvelope';
+import {
+    ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID,
+    ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+    validateEnvelopeSchema,
+    validateEnvelopeSize,
+    validateEnvelopeUnsupportedVersion,
+} from '../worker/validateActivityEnvelope';
+import { findWorkflowArtifactPath, resolveArtifactGlobPaths } from './artifactPathResolution';
+import { validateJsonSchemaContent } from './jsonSchemaValidation';
+import type {
+    RuntimeValidationDiagnostic,
+    ValidationNodeValidator,
+    ValidatorExecutorContext,
+    ValidatorExecutorResult,
+} from './types';
+
+export const ARTIFACT_EXISTS_VALIDATOR_ID = 'forge.artifact.exists';
+export const ARTIFACT_INTEGRITY_VALIDATOR_ID = 'forge.artifact.integrity';
+export const ARTIFACT_SCHEMA_VALIDATOR_ID = 'forge.artifact.schema';
+export const DOMAIN_EXIT_CRITERIA_VALIDATOR_ID = 'forge.domain.exit_criteria';
+export const REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID = 'local.forge.refine_issue.exit_criteria';
+
+function mapEnvelopeDiagnostic(
+    diagnostic: {
+        code: string;
+        severity: 'error' | 'warning' | 'info';
+        message: string;
+        path?: string;
+        validator_id: string;
+    }
+): RuntimeValidationDiagnostic {
+    return {
+        code: diagnostic.code,
+        severity: diagnostic.severity,
+        message: diagnostic.message,
+        validator_id: diagnostic.validator_id,
+        ...(diagnostic.path ? { path: diagnostic.path } : {}),
+    };
+}
+
+function runEnvelopeValidator(
+    validatorId: string,
+    validate: (content: unknown) => { valid: boolean; diagnostics: Array<{ code: string; severity: 'error' | 'warning' | 'info'; message: string; path?: string; validator_id: string }> },
+    envelope: CursorSdkResponseEnvelope | undefined
+): ValidatorExecutorResult {
+    if (!envelope) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.envelope.missing',
+                    severity: 'error',
+                    message: 'activity envelope is required for envelope validation',
+                    validator_id: validatorId,
+                },
+            ],
+        };
+    }
+
+    const result = validate(envelope);
+    return {
+        passed: result.valid,
+        diagnostics: result.diagnostics.map(mapEnvelopeDiagnostic),
+    };
+}
+
+export function executeEnvelopeSchemaValidator(
+    _declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    return runEnvelopeValidator(ACTIVITY_ENVELOPE_SCHEMA_VALIDATOR_ID, validateEnvelopeSchema, context.envelope);
+}
+
+export function executeEnvelopeUnsupportedVersionValidator(
+    _declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    return runEnvelopeValidator(
+        ACTIVITY_ENVELOPE_UNSUPPORTED_VERSION_VALIDATOR_ID,
+        validateEnvelopeUnsupportedVersion,
+        context.envelope
+    );
+}
+
+export function executeEnvelopeSizeValidator(
+    _declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    return runEnvelopeValidator(ACTIVITY_ENVELOPE_SIZE_VALIDATOR_ID, validateEnvelopeSize, context.envelope);
+}
+
+export function executeArtifactExistsValidator(
+    declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    const artifactId = declaration.target;
+    if (!artifactId) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.missing_target',
+                    severity: 'error',
+                    message: 'artifact validator requires target artifact_id',
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                },
+            ],
+        };
+    }
+
+    const artifactPath = findWorkflowArtifactPath(context.workflowArtifacts, artifactId);
+    if (!artifactPath) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.undeclared',
+                    severity: 'error',
+                    message: `workflow artifact "${artifactId}" is not declared`,
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    path: artifactId,
+                },
+            ],
+        };
+    }
+
+    const matches = resolveArtifactGlobPaths(context.workspaceRoot, artifactPath);
+    if (matches.length === 0) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.not_found',
+                    severity: 'error',
+                    message: `no on-disk match for artifact "${artifactId}" at pattern "${artifactPath}"`,
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    path: artifactPath,
+                },
+            ],
+        };
+    }
+
+    return { passed: true, diagnostics: [] };
+}
+
+function sha256HexFile(absolutePath: string): string {
+    const content = fs.readFileSync(absolutePath);
+    return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+export function executeArtifactIntegrityValidator(
+    _declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    const artifactRefs = context.envelope?.artifact_refs ?? [];
+    if (artifactRefs.length === 0) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.integrity.no_refs',
+                    severity: 'error',
+                    message: 'artifact integrity validation requires envelope artifact_refs',
+                    validator_id: ARTIFACT_INTEGRITY_VALIDATOR_ID,
+                },
+            ],
+        };
+    }
+
+    const diagnostics: RuntimeValidationDiagnostic[] = [];
+
+    for (const artifactRef of artifactRefs) {
+        if (!artifactRef.path || !artifactRef.sha256) {
+            continue;
+        }
+
+        const absolutePath = path.join(context.workspaceRoot, artifactRef.path);
+        if (!fs.existsSync(absolutePath)) {
+            continue;
+        }
+
+        const actualHash = sha256HexFile(absolutePath);
+        const expectedHash = artifactRef.sha256.toLowerCase();
+        if (actualHash !== expectedHash) {
+            diagnostics.push({
+                code: 'forge.artifact.integrity.mismatch',
+                severity: 'error',
+                message: `SHA-256 mismatch for artifact "${artifactRef.artifact_id}" at "${artifactRef.path}"`,
+                validator_id: ARTIFACT_INTEGRITY_VALIDATOR_ID,
+                path: artifactRef.path,
+            });
+        }
+    }
+
+    return {
+        passed: diagnostics.length === 0,
+        diagnostics,
+    };
+}
+
+function readArtifactContent(absolutePath: string): unknown {
+    const raw = fs.readFileSync(absolutePath, 'utf8');
+    return JSON.parse(raw) as unknown;
+}
+
+export function executeArtifactSchemaValidator(
+    declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    const schemaRef =
+        declaration.target ?? context.envelope?.validation_inputs?.schema_ref;
+
+    if (!schemaRef) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.schema.missing_ref',
+                    severity: 'error',
+                    message: 'artifact schema validator requires target schema ref or envelope validation_inputs.schema_ref',
+                    validator_id: ARTIFACT_SCHEMA_VALIDATOR_ID,
+                },
+            ],
+        };
+    }
+
+    const artifactId = context.envelope?.validation_inputs?.artifact_ids?.[0];
+    let artifactPath: string | undefined;
+
+    if (artifactId) {
+        artifactPath = findWorkflowArtifactPath(context.workflowArtifacts, artifactId);
+    }
+
+    if (!artifactPath && context.envelope?.artifact_refs?.[0]?.path) {
+        artifactPath = context.envelope.artifact_refs[0].path;
+    }
+
+    if (!artifactPath) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.schema.missing_artifact',
+                    severity: 'error',
+                    message: 'artifact schema validator could not resolve artifact path',
+                    validator_id: ARTIFACT_SCHEMA_VALIDATOR_ID,
+                },
+            ],
+        };
+    }
+
+    const matches = resolveArtifactGlobPaths(context.workspaceRoot, artifactPath);
+    if (matches.length === 0) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.not_found',
+                    severity: 'error',
+                    message: `no on-disk match for artifact schema validation at "${artifactPath}"`,
+                    validator_id: ARTIFACT_SCHEMA_VALIDATOR_ID,
+                    path: artifactPath,
+                },
+            ],
+        };
+    }
+
+    const absolutePath = path.join(context.workspaceRoot, matches[0]);
+    let content: unknown;
+    try {
+        content = readArtifactContent(absolutePath);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'invalid artifact content';
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.artifact.schema.read_error',
+                    severity: 'error',
+                    message: `failed to read artifact for schema validation: ${message}`,
+                    validator_id: ARTIFACT_SCHEMA_VALIDATOR_ID,
+                    path: matches[0],
+                },
+            ],
+        };
+    }
+
+    const validation = validateJsonSchemaContent(content, {
+        schemaRelativePath: schemaRef,
+        validatorId: ARTIFACT_SCHEMA_VALIDATOR_ID,
+    });
+
+    return {
+        passed: validation.valid,
+        diagnostics: validation.diagnostics.map((diagnostic) => ({
+            ...diagnostic,
+            path: diagnostic.path ?? matches[0],
+        })),
+    };
+}
+
+export function executeDomainExitCriteriaValidator(
+    declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    const criterionId = declaration.target;
+    if (!criterionId) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.domain.missing_target',
+                    severity: 'error',
+                    message: 'domain exit criteria validator requires target criterion id',
+                    validator_id: DOMAIN_EXIT_CRITERIA_VALIDATOR_ID,
+                },
+            ],
+        };
+    }
+
+    const met = context.domainExitCriteria?.criteriaMet[criterionId];
+    if (met !== true) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.domain.exit_criteria.unmet',
+                    severity: 'error',
+                    message: `domain exit criterion "${criterionId}" is not satisfied`,
+                    validator_id: DOMAIN_EXIT_CRITERIA_VALIDATOR_ID,
+                    path: criterionId,
+                },
+            ],
+        };
+    }
+
+    return { passed: true, diagnostics: [] };
+}
+
+export function executeRefineIssueExitCriteriaValidator(
+    _declaration: ValidationNodeValidator,
+    context: ValidatorExecutorContext
+): ValidatorExecutorResult {
+    const exitContext = context.refineIssueExitContext;
+    if (!exitContext) {
+        return {
+            passed: false,
+            diagnostics: [
+                {
+                    code: 'forge.refine_issue.exit_criteria.missing_context',
+                    severity: 'error',
+                    message: 'refine-issue exit criteria context is required',
+                    validator_id: REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID,
+                },
+            ],
+        };
+    }
+
+    const checks: Array<{ key: keyof typeof exitContext; label: string }> = [
+        { key: 'issueBodyValid', label: 'working parent issue body satisfies mandatory ticket format' },
+        { key: 'blockersResolved', label: 'no unanswered tier-User blockers remain' },
+        { key: 'openDecisionsResolved', label: 'in-scope Open implementation decisions are resolved in .ai' },
+        { key: 'aiChangesCommitted', label: '.ai edits are committed and pushed to main from the worktree' },
+    ];
+
+    const diagnostics: RuntimeValidationDiagnostic[] = [];
+
+    for (const check of checks) {
+        if (!exitContext[check.key]) {
+            diagnostics.push({
+                code: 'forge.refine_issue.exit_criteria.unmet',
+                severity: 'error',
+                message: check.label,
+                validator_id: REFINE_ISSUE_EXIT_CRITERIA_VALIDATOR_ID,
+                path: check.key,
+            });
+        }
+    }
+
+    return {
+        passed: diagnostics.length === 0,
+        diagnostics,
+    };
+}

--- a/src/worker/executeValidationGateActivity.test.ts
+++ b/src/worker/executeValidationGateActivity.test.ts
@@ -1,0 +1,156 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetJsonSchemaValidatorCacheForTests } from '../validation/jsonSchemaValidation';
+import { ARTIFACT_EXISTS_VALIDATOR_ID } from '../validation/validators';
+import type { WorkflowArtifactDefinition } from '../validation';
+import {
+    executeValidationGateActivity,
+    VALIDATION_GATE_ACTIVITY_ID,
+} from './executeValidationGateActivity';
+import { buildValidationGateActivityOptions } from './temporalActivityPolicyOptions';
+
+const tempDirs: string[] = [];
+
+const refineIssueArtifacts: WorkflowArtifactDefinition[] = [
+    {
+        artifact_id: 'user_questions',
+        path: '.cursor/.tmp/refine-*/user_questions.md',
+    },
+    {
+        artifact_id: 'assumptions',
+        path: '.cursor/.tmp/refine-*/assumptions.md',
+    },
+];
+
+function createTempWorkspace(): string {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validation-gate-'));
+    tempDirs.push(workspaceRoot);
+    return workspaceRoot;
+}
+
+afterEach(() => {
+    resetJsonSchemaValidatorCacheForTests();
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+describe('executeValidationGateActivity', () => {
+    it('exposes the forge.validation.executeGate activity id', () => {
+        expect(VALIDATION_GATE_ACTIVITY_ID).toBe('forge.validation.executeGate');
+    });
+
+    it('returns a schema-valid aggregate when triage artifacts exist', async () => {
+        const workspaceRoot = createTempWorkspace();
+        const sessionDir = path.join(workspaceRoot, '.cursor', '.tmp', 'refine-forge-51');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'user_questions.md'), '# Questions');
+        fs.writeFileSync(path.join(sessionDir, 'assumptions.md'), '# Assumptions');
+
+        const result = await executeValidationGateActivity({
+            nodeId: 'validate_triage_artifacts',
+            workflowRunId: 'run-51',
+            workspaceRoot,
+            sourceActivityNodeId: 'triage_questions',
+            validators: [
+                {
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    type: 'artifact',
+                    target: 'user_questions',
+                },
+                {
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    type: 'artifact',
+                    target: 'assumptions',
+                },
+            ],
+            workflowArtifacts: refineIssueArtifacts,
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.node_id).toBe('validate_triage_artifacts');
+        expect(result.source_activity_node_id).toBe('triage_questions');
+        expect(result.validator_outcomes).toHaveLength(2);
+    });
+
+    it('returns valid=false without throwing when artifacts are missing', async () => {
+        const workspaceRoot = createTempWorkspace();
+
+        const result = await executeValidationGateActivity({
+            nodeId: 'validate_triage_artifacts',
+            workflowRunId: 'run-51',
+            workspaceRoot,
+            validators: [
+                {
+                    validator_id: ARTIFACT_EXISTS_VALIDATOR_ID,
+                    type: 'artifact',
+                    target: 'user_questions',
+                },
+            ],
+            workflowArtifacts: refineIssueArtifacts,
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.diagnostics).toHaveLength(1);
+        expect(result.diagnostics[0]?.validator_id).toBe(ARTIFACT_EXISTS_VALIDATOR_ID);
+    });
+
+    it('evaluates refine-issue exit criteria when context is supplied', async () => {
+        const workspaceRoot = createTempWorkspace();
+
+        const passResult = await executeValidationGateActivity({
+            nodeId: 'validate_exit_criteria',
+            workflowRunId: 'run-51',
+            workspaceRoot,
+            validators: [
+                {
+                    validator_id: 'local.forge.refine_issue.exit_criteria',
+                    type: 'domain',
+                },
+            ],
+            refineIssueExitContext: {
+                issueBodyValid: true,
+                blockersResolved: true,
+                openDecisionsResolved: true,
+                aiChangesCommitted: true,
+            },
+        });
+
+        expect(passResult.valid).toBe(true);
+
+        const failResult = await executeValidationGateActivity({
+            nodeId: 'validate_exit_criteria',
+            workflowRunId: 'run-51',
+            workspaceRoot,
+            validators: [
+                {
+                    validator_id: 'local.forge.refine_issue.exit_criteria',
+                    type: 'domain',
+                },
+            ],
+            refineIssueExitContext: {
+                issueBodyValid: true,
+                blockersResolved: false,
+                openDecisionsResolved: true,
+                aiChangesCommitted: true,
+            },
+        });
+
+        expect(failResult.valid).toBe(false);
+        expect(failResult.diagnostics.some((diagnostic) => diagnostic.path === 'blockersResolved')).toBe(
+            true
+        );
+    });
+});
+
+describe('buildValidationGateActivityOptions', () => {
+    it('uses retry_policy none so validation failures do not consume retry budget', () => {
+        const options = buildValidationGateActivityOptions();
+
+        expect(options.startToCloseTimeout).toBe(5 * 60 * 1_000);
+        expect(options.scheduleToCloseTimeout).toBe(10 * 60 * 1_000);
+        expect(options.retry?.maximumAttempts).toBe(1);
+    });
+});

--- a/src/worker/executeValidationGateActivity.ts
+++ b/src/worker/executeValidationGateActivity.ts
@@ -1,0 +1,60 @@
+import path from 'path';
+import type { CursorSdkResponseEnvelope } from './activityEnvelope';
+import {
+    assembleRuntimeValidationResult,
+    validateRuntimeValidationResultSchema,
+} from '../validation';
+import type {
+    DomainExitCriteriaContext,
+    RefineIssueExitCriteriaContext,
+    RuntimeValidationResult,
+    ValidationNodeValidator,
+    WorkflowArtifactDefinition,
+} from '../validation';
+
+export const VALIDATION_GATE_ACTIVITY_ID = 'forge.validation.executeGate';
+
+export interface ExecuteValidationGateActivityInput {
+    nodeId: string;
+    nodeName?: string;
+    workflowRunId: string;
+    workspaceRoot: string;
+    validators: ValidationNodeValidator[];
+    sourceActivityNodeId?: string;
+    workflowArtifacts?: WorkflowArtifactDefinition[];
+    envelope?: CursorSdkResponseEnvelope;
+    domainExitCriteria?: DomainExitCriteriaContext;
+    refineIssueExitContext?: RefineIssueExitCriteriaContext;
+}
+
+export async function executeValidationGateActivity(
+    input: ExecuteValidationGateActivityInput
+): Promise<RuntimeValidationResult> {
+    const workspaceRoot = path.resolve(input.workspaceRoot);
+    const result = assembleRuntimeValidationResult({
+        nodeId: input.nodeId,
+        workflowRunId: input.workflowRunId,
+        sourceActivityNodeId: input.sourceActivityNodeId,
+        validators: input.validators,
+        context: {
+            workspaceRoot,
+            workflowRunId: input.workflowRunId,
+            nodeId: input.nodeId,
+            sourceActivityNodeId: input.sourceActivityNodeId,
+            envelope: input.envelope,
+            workflowArtifacts: input.workflowArtifacts,
+            domainExitCriteria: input.domainExitCriteria,
+            refineIssueExitContext: input.refineIssueExitContext,
+        },
+    });
+
+    const schemaValidation = validateRuntimeValidationResultSchema(result);
+    if (!schemaValidation.valid) {
+        const firstError = schemaValidation.diagnostics.find((diagnostic) => diagnostic.severity === 'error');
+        throw new Error(
+            firstError?.message ?? 'validation gate produced an aggregate that failed schema validation'
+        );
+    }
+
+    return result;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -50,3 +50,18 @@ export {
     ENVELOPE_UNSUPPORTED_VERSION_CODE,
     ENVELOPE_SIZE_EXCEEDED_CODE,
 } from './validateActivityEnvelope';
+export {
+    assembleRuntimeValidationResult,
+    executeRegisteredValidator,
+    getValidatorExecutor,
+    isRuntimeCatalogValidatorId,
+    RUNTIME_CATALOG_VALIDATOR_IDS,
+    validateRuntimeValidationResultSchema,
+} from '../validation';
+export type {
+    RuntimeValidationDiagnostic,
+    RuntimeValidationResult,
+    RuntimeValidatorOutcome,
+    ValidatorExecutorContext,
+    WorkflowArtifactDefinition,
+} from '../validation';

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,6 +1,10 @@
 import type { ActivityNodePolicyRefs } from '../workflows/activityPolicyRegistry';
 import type { ExecuteCursorSdkAgentActivityInput } from './activityEnvelope';
 import { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
+import {
+    executeValidationGateActivity,
+    type ExecuteValidationGateActivityInput,
+} from './executeValidationGateActivity';
 import { mapEnvelopeToActivityFailure } from './mapEnvelopeToActivityFailure';
 
 export interface RegisteredCursorSdkAgentActivityInput extends ExecuteCursorSdkAgentActivityInput {
@@ -18,14 +22,30 @@ async function executeRegisteredCursorSdkAgentActivity(
     return response;
 }
 
+async function executeRegisteredValidationGateActivity(
+    input: ExecuteValidationGateActivityInput
+): Promise<ReturnType<typeof executeValidationGateActivity>> {
+    return executeValidationGateActivity(input);
+}
+
 export function createWorkerActivities() {
     return {
         executeCursorSdkAgentActivity: executeRegisteredCursorSdkAgentActivity,
+        executeValidationGate: executeRegisteredValidationGateActivity,
     };
 }
 
 export { executeCursorSdkAgentActivity } from './executeCursorSdkAgentActivity';
-export { buildTemporalActivityOptions } from './temporalActivityPolicyOptions';
+export {
+    executeValidationGateActivity,
+    VALIDATION_GATE_ACTIVITY_ID,
+} from './executeValidationGateActivity';
+export type { ExecuteValidationGateActivityInput } from './executeValidationGateActivity';
+export {
+    buildTemporalActivityOptions,
+    buildValidationGateActivityOptions,
+    VALIDATION_GATE_POLICY_REFS,
+} from './temporalActivityPolicyOptions';
 export { mapEnvelopeToActivityFailure } from './mapEnvelopeToActivityFailure';
 export type {
     ActivityArtifactRef,

--- a/src/worker/temporalActivityPolicyOptions.test.ts
+++ b/src/worker/temporalActivityPolicyOptions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildTemporalActivityOptions } from './temporalActivityPolicyOptions';
+import {
+    buildTemporalActivityOptions,
+    buildValidationGateActivityOptions,
+} from './temporalActivityPolicyOptions';
 
 describe('buildTemporalActivityOptions', () => {
     it('applies agent_default and agent_standard when node policies are omitted', () => {
@@ -26,6 +29,13 @@ describe('buildTemporalActivityOptions', () => {
 
         expect(options.startToCloseTimeout).toBe(5 * 60 * 1_000);
         expect(options.scheduleToCloseTimeout).toBe(10 * 60 * 1_000);
+        expect(options.retry?.maximumAttempts).toBe(1);
+    });
+
+    it('buildValidationGateActivityOptions uses none retry and agent_short timeout', () => {
+        const options = buildValidationGateActivityOptions();
+
+        expect(options.startToCloseTimeout).toBe(5 * 60 * 1_000);
         expect(options.retry?.maximumAttempts).toBe(1);
     });
 });

--- a/src/worker/temporalActivityPolicyOptions.ts
+++ b/src/worker/temporalActivityPolicyOptions.ts
@@ -7,6 +7,15 @@ import {
     type ActivityNodePolicyRefs,
 } from '../workflows/activityPolicyRegistry';
 
+export const VALIDATION_GATE_POLICY_REFS: ActivityNodePolicyRefs = {
+    retry_policy: 'none',
+    timeout_policy: 'agent_short',
+};
+
+export function buildValidationGateActivityOptions(): ActivityOptions {
+    return buildTemporalActivityOptions(VALIDATION_GATE_POLICY_REFS);
+}
+
 export function buildTemporalActivityOptions(policyRefs: ActivityNodePolicyRefs = {}): ActivityOptions {
     const retryPolicyId = resolveRetryPolicyId(policyRefs);
     const timeoutPolicyId = resolveTimeoutPolicyId(policyRefs);

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -53,3 +53,14 @@ export {
     gateWorkflowRunStartWithTemporalReadiness,
     validateWorkflowForRun,
 } from './validateWorkflowForRun';
+export {
+    REFINE_ISSUE_VALIDATION_NODE_IDS,
+    buildRefineIssueValidationGateInput,
+    findValidationNode,
+    resolveValidationTransition,
+    shouldAdvanceAfterValidation,
+} from './runtime/validationGateOrchestration';
+export type {
+    ValidationTransitionResult,
+    WorkflowValidationNode,
+} from './runtime/validationGateOrchestration';

--- a/src/workflows/runtime/validationGateOrchestration.test.ts
+++ b/src/workflows/runtime/validationGateOrchestration.test.ts
@@ -1,0 +1,202 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetJsonSchemaValidatorCacheForTests } from '../../validation/jsonSchemaValidation';
+import type { WorkflowArtifactDefinition } from '../../validation';
+import { executeValidationGateActivity } from '../../worker/executeValidationGateActivity';
+import {
+    REFINE_ISSUE_VALIDATION_NODE_IDS,
+    buildRefineIssueValidationGateInput,
+    findValidationNode,
+    resolveValidationTransition,
+    shouldAdvanceAfterValidation,
+} from './validationGateOrchestration';
+
+const REFINE_ISSUE_PATH = '.ai/workflows/refine-issue.json';
+const tempDirs: string[] = [];
+
+function createTempWorkspace(): string {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-refine-validation-gate-'));
+    tempDirs.push(workspaceRoot);
+    return workspaceRoot;
+}
+
+function loadRefineIssueDefinition(): {
+    artifacts: WorkflowArtifactDefinition[];
+    nodes: Array<{ node_id: string; type: string; name: string; validators?: Array<{ validator_id: string; type: string; target?: string }> }>;
+} {
+    const absolutePath = path.join(process.cwd(), REFINE_ISSUE_PATH);
+    return JSON.parse(fs.readFileSync(absolutePath, 'utf8')) as {
+        artifacts: WorkflowArtifactDefinition[];
+        nodes: Array<{
+            node_id: string;
+            type: string;
+            name: string;
+            validators?: Array<{ validator_id: string; type: string; target?: string }>;
+        }>;
+    };
+}
+
+afterEach(() => {
+    resetJsonSchemaValidatorCacheForTests();
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+describe('validation gate orchestration', () => {
+    it('blocks transitions when validation fails and advances when valid', () => {
+        const node = {
+            node_id: 'validate_triage_artifacts',
+            type: 'validation' as const,
+            name: 'Validate triage artifacts',
+            validators: [],
+            transitions: [{ to_node_id: 'user_verification_batch' }],
+        };
+
+        const blocked = resolveValidationTransition(node, {
+            valid: false,
+            node_id: node.node_id,
+            workflow_run_id: 'run-1',
+            validated_at: '2026-06-10T12:00:00.000Z',
+            diagnostics: [],
+            validator_outcomes: [],
+        });
+
+        expect(blocked.advance).toBe(false);
+        expect(blocked.validationFailed).toBe(true);
+        expect(blocked.failedNodeId).toBe('validate_triage_artifacts');
+        expect(blocked.nextNodeId).toBeUndefined();
+
+        const advanced = resolveValidationTransition(node, {
+            valid: true,
+            node_id: node.node_id,
+            workflow_run_id: 'run-1',
+            validated_at: '2026-06-10T12:00:00.000Z',
+            diagnostics: [],
+            validator_outcomes: [],
+        });
+
+        expect(advanced.advance).toBe(true);
+        expect(advanced.validationFailed).toBe(false);
+        expect(advanced.nextNodeId).toBe('user_verification_batch');
+        expect(
+            shouldAdvanceAfterValidation({
+                valid: true,
+                node_id: node.node_id,
+                workflow_run_id: 'run-1',
+                validated_at: '2026-06-10T12:00:00.000Z',
+                diagnostics: [],
+                validator_outcomes: [],
+            })
+        ).toBe(true);
+    });
+});
+
+describe('refine-issue validation gate integration', () => {
+    it('wires validate_triage_artifacts and blocks when user_questions is missing', async () => {
+        const definition = loadRefineIssueDefinition();
+        const node = findValidationNode(definition.nodes, REFINE_ISSUE_VALIDATION_NODE_IDS.triageArtifacts);
+        expect(node).toBeDefined();
+
+        const workspaceRoot = createTempWorkspace();
+        const sessionDir = path.join(workspaceRoot, '.cursor', '.tmp', 'refine-forge-51');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'assumptions.md'), '# Assumptions');
+
+        const gateInput = buildRefineIssueValidationGateInput({
+            node: node!,
+            workflowRunId: 'run-51',
+            workspaceRoot,
+            workflowArtifacts: definition.artifacts,
+            sourceActivityNodeId: 'triage_questions',
+        });
+
+        const result = await executeValidationGateActivity(gateInput);
+        const transition = resolveValidationTransition(node!, result);
+
+        expect(result.valid).toBe(false);
+        expect(transition.validationFailed).toBe(true);
+        expect(transition.advance).toBe(false);
+    });
+
+    it('wires validate_triage_artifacts and advances when artifacts exist', async () => {
+        const definition = loadRefineIssueDefinition();
+        const node = findValidationNode(definition.nodes, REFINE_ISSUE_VALIDATION_NODE_IDS.triageArtifacts);
+        expect(node).toBeDefined();
+
+        const workspaceRoot = createTempWorkspace();
+        const sessionDir = path.join(workspaceRoot, '.cursor', '.tmp', 'refine-forge-51');
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'user_questions.md'), '# Questions');
+        fs.writeFileSync(path.join(sessionDir, 'assumptions.md'), '# Assumptions');
+
+        const result = await executeValidationGateActivity(
+            buildRefineIssueValidationGateInput({
+                node: node!,
+                workflowRunId: 'run-51',
+                workspaceRoot,
+                workflowArtifacts: definition.artifacts,
+                sourceActivityNodeId: 'triage_questions',
+            })
+        );
+        const transition = resolveValidationTransition(node!, result);
+
+        expect(result.valid).toBe(true);
+        expect(transition.advance).toBe(true);
+        expect(transition.nextNodeId).toBe('user_verification_batch');
+    });
+
+    it('wires validate_exit_criteria and blocks when blockers remain', async () => {
+        const definition = loadRefineIssueDefinition();
+        const node = findValidationNode(definition.nodes, REFINE_ISSUE_VALIDATION_NODE_IDS.exitCriteria);
+        expect(node).toBeDefined();
+
+        const result = await executeValidationGateActivity(
+            buildRefineIssueValidationGateInput({
+                node: node!,
+                workflowRunId: 'run-51',
+                workspaceRoot: createTempWorkspace(),
+                workflowArtifacts: definition.artifacts,
+                refineIssueExitContext: {
+                    issueBodyValid: true,
+                    blockersResolved: false,
+                    openDecisionsResolved: true,
+                    aiChangesCommitted: true,
+                },
+            })
+        );
+        const transition = resolveValidationTransition(node!, result);
+
+        expect(result.valid).toBe(false);
+        expect(transition.validationFailed).toBe(true);
+        expect(transition.nextNodeId).toBeUndefined();
+    });
+
+    it('wires validate_exit_criteria and advances when exit criteria are met', async () => {
+        const definition = loadRefineIssueDefinition();
+        const node = findValidationNode(definition.nodes, REFINE_ISSUE_VALIDATION_NODE_IDS.exitCriteria);
+        expect(node).toBeDefined();
+
+        const result = await executeValidationGateActivity(
+            buildRefineIssueValidationGateInput({
+                node: node!,
+                workflowRunId: 'run-51',
+                workspaceRoot: createTempWorkspace(),
+                workflowArtifacts: definition.artifacts,
+                refineIssueExitContext: {
+                    issueBodyValid: true,
+                    blockersResolved: true,
+                    openDecisionsResolved: true,
+                    aiChangesCommitted: true,
+                },
+            })
+        );
+        const transition = resolveValidationTransition(node!, result);
+
+        expect(result.valid).toBe(true);
+        expect(transition.advance).toBe(true);
+        expect(transition.nextNodeId).toBe('commit_ai_contracts');
+    });
+});

--- a/src/workflows/runtime/validationGateOrchestration.ts
+++ b/src/workflows/runtime/validationGateOrchestration.ts
@@ -1,0 +1,86 @@
+import type { ExecuteValidationGateActivityInput } from '../../worker/executeValidationGateActivity';
+import type {
+    RefineIssueExitCriteriaContext,
+    RuntimeValidationResult,
+    ValidationNodeValidator,
+    WorkflowArtifactDefinition,
+} from '../../validation';
+import type { CursorSdkResponseEnvelope } from '../../worker/activityEnvelope';
+
+export interface WorkflowValidationNode {
+    node_id: string;
+    type: 'validation';
+    name: string;
+    validators: ValidationNodeValidator[];
+    transitions?: Array<{ to_node_id: string; condition?: string }>;
+}
+
+export interface ValidationTransitionResult {
+    advance: boolean;
+    nextNodeId?: string;
+    failedNodeId?: string;
+    validationFailed: boolean;
+}
+
+export const REFINE_ISSUE_VALIDATION_NODE_IDS = {
+    triageArtifacts: 'validate_triage_artifacts',
+    exitCriteria: 'validate_exit_criteria',
+} as const;
+
+export function resolveValidationTransition(
+    node: WorkflowValidationNode,
+    result: RuntimeValidationResult
+): ValidationTransitionResult {
+    if (!result.valid) {
+        return {
+            advance: false,
+            failedNodeId: node.node_id,
+            validationFailed: true,
+        };
+    }
+
+    const nextNodeId = node.transitions?.[0]?.to_node_id;
+    return {
+        advance: Boolean(nextNodeId),
+        nextNodeId,
+        validationFailed: false,
+    };
+}
+
+export function shouldAdvanceAfterValidation(result: RuntimeValidationResult): boolean {
+    return result.valid;
+}
+
+export function buildRefineIssueValidationGateInput(input: {
+    node: WorkflowValidationNode;
+    workflowRunId: string;
+    workspaceRoot: string;
+    workflowArtifacts: WorkflowArtifactDefinition[];
+    sourceActivityNodeId?: string;
+    envelope?: CursorSdkResponseEnvelope;
+    refineIssueExitContext?: RefineIssueExitCriteriaContext;
+}): ExecuteValidationGateActivityInput {
+    return {
+        nodeId: input.node.node_id,
+        nodeName: input.node.name,
+        workflowRunId: input.workflowRunId,
+        workspaceRoot: input.workspaceRoot,
+        validators: input.node.validators,
+        sourceActivityNodeId: input.sourceActivityNodeId,
+        workflowArtifacts: input.workflowArtifacts,
+        envelope: input.envelope,
+        refineIssueExitContext: input.refineIssueExitContext,
+    };
+}
+
+export function findValidationNode(
+    nodes: Array<{ node_id: string; type: string }>,
+    nodeId: string
+): WorkflowValidationNode | undefined {
+    const node = nodes.find((candidate) => candidate.node_id === nodeId);
+    if (!node || node.type !== 'validation') {
+        return undefined;
+    }
+
+    return node as WorkflowValidationNode;
+}


### PR DESCRIPTION
## Description

Adds the runtime validation foundation for Forge workflow validation nodes and wires the Temporal validation gate activity for `/refine-issue`.

**#50** — Types aligned with `.ai/schemas/validation-result.schema.json`, JSON Schema validation helper, artifact glob path resolution, and a v1 validator registry with executors for envelope, artifact, and domain checks.

**#51** — `forge.validation.executeGate` worker activity (no-retry policy), orchestration helpers that block transitions when `valid=false`, refine-issue triage/exit validation node wiring, and `validationSummaries` on `WorkflowRunProjection`.

## Motivation and Context

Workflow validation nodes need deterministic, catalog-driven validators and a worker activity the orchestrator can schedule before advancing a run. This PR delivers the registry (#50) and the gate activity plus projection plumbing (#51) on the shared `feature/issue-24` branch.

Fixes #50
Fixes #51

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

Focused coverage:
- Registry dispatch for all v1 runtime catalog validator IDs (#50)
- `executeValidationGate` activity returns schema-valid aggregates; `valid=false` does not throw (#51)
- Validation gate uses `retry_policy: none` (maximumAttempts 1) (#51)
- refine-issue `validate_triage_artifacts` and `validate_exit_criteria` integration pass/fail paths (#51)
- `ValidationSummary` projection mapper and `failedNodeId` on validation failure (#51)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)
- [x] My changes generate no new warnings

## Additional Notes

Parent epic: #24. Temporal workflow orchestrator code that schedules activities at runtime is a follow-on; this PR supplies the worker activity, transition helpers, and cockpit projection fields the orchestrator will consume.