### PR TITLE
Validate submitted run inputs before Temporal start

### DIFF
--- a/src/temporal/startWorkflowRun.test.ts
+++ b/src/temporal/startWorkflowRun.test.ts
@@ -149,4 +149,72 @@ describe('startWorkflowRun', () => {
         fs.rmSync(root, { recursive: true, force: true });
     });
 
+    it('blocks before Temporal readiness when required run inputs are missing', async () => {
+        const { store: indexStore, root, windowId } = createIndexStore();
+        const startClient = vi.fn(async () => createMockStartClient());
+
+        const outcome = await startWorkflowRun({
+            repositoryRoot: process.cwd(),
+            workflowId: 'refine-issue',
+            submittedRunInputs: {},
+            globalStoragePath: root,
+            windowId,
+            indexStore,
+            createStartClient: startClient,
+        });
+
+        expect(outcome).toEqual({
+            ok: false,
+            diagnostics: expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'run_input.required_missing',
+                    path: '/run_inputs/issue_ref',
+                }),
+            ]),
+        });
+        expect(gateTemporalReadiness).not.toHaveBeenCalled();
+        expect(startClient).not.toHaveBeenCalled();
+        expect(indexStore.listEntries()).toEqual([]);
+
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('blocks undeclared submitted keys before Temporal start without creating run index state', async () => {
+        const { store: indexStore, root, windowId } = createIndexStore();
+        const startClient = vi.fn(async () => createMockStartClient());
+        const secretValue = 'undeclared-secret-value-xyz';
+
+        const outcome = await startWorkflowRun({
+            repositoryRoot: process.cwd(),
+            workflowId: 'refine-issue',
+            submittedRunInputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/76',
+                rogue_key: secretValue,
+            },
+            globalStoragePath: root,
+            windowId,
+            indexStore,
+            createStartClient: startClient,
+        });
+
+        expect(outcome.ok).toBe(false);
+        if (outcome.ok) {
+            return;
+        }
+
+        expect(outcome.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'run_input.undeclared_key',
+                    path: '/run_inputs/rogue_key',
+                }),
+            ])
+        );
+        expect(JSON.stringify(outcome.diagnostics)).not.toContain(secretValue);
+        expect(gateTemporalReadiness).not.toHaveBeenCalled();
+        expect(startClient).not.toHaveBeenCalled();
+        expect(indexStore.listEntries()).toEqual([]);
+
+        fs.rmSync(root, { recursive: true, force: true });
+    });
 });

--- a/src/workflows/validateSubmittedRunInputs.test.ts
+++ b/src/workflows/validateSubmittedRunInputs.test.ts
@@ -108,6 +108,85 @@ describe('validateSubmittedRunInputs', () => {
             ])
         );
     });
+
+    it('accepts optional missing inputs when required values are present', () => {
+        const result = validateSubmittedRunInputs({
+            declarations,
+            submitted: {
+                issue_ref: 'https://github.com/alto9/forge/issues/76',
+            },
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('accepts workflows with no declared inputs', () => {
+        const result = validateSubmittedRunInputs({
+            declarations: [],
+            submitted: {},
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.diagnostics).toEqual([]);
+    });
+
+    it('does not include raw submitted values in diagnostics', () => {
+        const secretValue = 'super-secret-token-abc123xyz';
+        const result = validateSubmittedRunInputs({
+            declarations,
+            submitted: {
+                issue_ref: secretValue,
+                secret_token: secretValue,
+            },
+        });
+
+        expect(result.valid).toBe(false);
+        const serialized = JSON.stringify(result.diagnostics);
+        expect(serialized).not.toContain(secretValue);
+        expect(result.diagnostics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    code: 'run_input.undeclared_key',
+                    path: '/run_inputs/secret_token',
+                }),
+            ])
+        );
+    });
+
+    it('validates required issue_ref for refine-issue style declarations', () => {
+        const refineIssueDeclarations: WorkflowRunInputDefinition[] = [
+            {
+                input_id: 'issue_ref',
+                type: 'string',
+                label: 'GitHub issue',
+                required: true,
+            },
+        ];
+
+        const missing = validateSubmittedRunInputs({
+            declarations: refineIssueDeclarations,
+            submitted: {},
+            workflow_id: 'refine-issue',
+        });
+        expect(missing.valid).toBe(false);
+        expect(missing.diagnostics).toEqual([
+            expect.objectContaining({
+                code: 'run_input.required_missing',
+                path: '/run_inputs/issue_ref',
+                validator_id: WORKFLOW_RUN_INPUT_VALIDATOR_ID,
+            }),
+        ]);
+
+        const accepted = validateSubmittedRunInputs({
+            declarations: refineIssueDeclarations,
+            submitted: {
+                issue_ref: 'https://github.com/alto9/forge/issues/76',
+            },
+            workflow_id: 'refine-issue',
+        });
+        expect(accepted.valid).toBe(true);
+    });
 });
 
 describe('normalizeSubmittedRunInputs', () => {
@@ -120,5 +199,10 @@ describe('normalizeSubmittedRunInputs', () => {
         ).toEqual({
             issue_ref: 'https://github.com/alto9/forge/issues/75',
         });
+    });
+
+    it('normalizes to an empty object when no inputs are declared', () => {
+        expect(normalizeSubmittedRunInputs([], {})).toEqual({});
+        expect(normalizeSubmittedRunInputs([], { stray: 'ignored' })).toEqual({});
     });
 });


### PR DESCRIPTION
## Description

Completes issue #76 test coverage for the submitted run-input pre-start gate. Core validation (`validateSubmittedRunInputs`, normalization, and `startWorkflowRun` ordering before Temporal readiness) landed with #75; this PR locks in acceptance criteria with focused tests.

## Motivation and Context

Fixes #76

Forge must reject missing required inputs, undeclared keys, and non-string values before Temporal creates durable run history or local run-index entries.

## Type of Change

- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] `npm run lint`
- [x] `npm run build`

Focused coverage:
- Optional missing inputs and empty declaration lists normalize to `{}`
- Diagnostics never include raw submitted values
- Required `issue_ref` validation for refine-issue-style declarations
- `startWorkflowRun` blocks before `gateTemporalReadiness` and skips Temporal start / run index writes on input validation failure

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)