### PR TITLE
Migrate /refine-issue issue context into declared run inputs (#77)

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,10 @@
         "title": "Forge: Open Question Panel"
       },
       {
+        "command": "forge.refineIssue",
+        "title": "Forge: Refine Issue"
+      },
+      {
         "command": "forge.openWorkflowCatalog",
         "title": "Forge: Open Workflow Catalog"
       },

--- a/src/commands/RefineIssueCommand.test.ts
+++ b/src/commands/RefineIssueCommand.test.ts
@@ -1,0 +1,193 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RefineIssueCommand, REFINE_ISSUE_WORKFLOW_ID } from '../commands/RefineIssueCommand';
+import { WorkflowCatalogCommand } from '../commands/WorkflowCatalogCommand';
+import { startWorkflowRun } from '../temporal/startWorkflowRun';
+import { getWorkflowRunRecoveryContext } from '../temporal/workflowRunRecoveryService';
+import * as vscode from 'vscode';
+
+vi.mock('../temporal/startWorkflowRun', () => ({
+    startWorkflowRun: vi.fn(),
+}));
+
+vi.mock('../temporal/workflowRunRecoveryService', () => ({
+    getWorkflowRunRecoveryContext: vi.fn(),
+}));
+
+vi.mock('../commands/WorkflowCatalogCommand', () => ({
+    WorkflowCatalogCommand: {
+        resolveRepositoryFolder: vi.fn(),
+    },
+}));
+
+const mockedStartWorkflowRun = vi.mocked(startWorkflowRun);
+const mockedGetWorkflowRunRecoveryContext = vi.mocked(getWorkflowRunRecoveryContext);
+const mockedResolveRepositoryFolder = vi.mocked(WorkflowCatalogCommand.resolveRepositoryFolder);
+
+describe('RefineIssueCommand', () => {
+    let tempRoot: string;
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        if (tempRoot && fs.existsSync(tempRoot)) {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    it('submits run_inputs.issue_ref through the generic start path for a full issue URL', async () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-refine-issue-command-'));
+        fs.mkdirSync(path.join(tempRoot, '.ai'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.ai/project.json'),
+            JSON.stringify({ github_url: 'https://github.com/alto9/forge' })
+        );
+
+        mockedResolveRepositoryFolder.mockResolvedValue({
+            uri: vscode.Uri.file(tempRoot),
+            name: 'forge',
+            index: 0,
+        } as vscode.WorkspaceFolder);
+
+        mockedGetWorkflowRunRecoveryContext.mockReturnValue({
+            globalStoragePath: tempRoot,
+            windowId: 'window-test',
+            indexStore: {} as never,
+            log: vi.fn(),
+            createRecoveryClient: vi.fn(),
+            isReady: () => true,
+        });
+
+        mockedStartWorkflowRun.mockResolvedValue({
+            ok: true,
+            workflowId: 'refine-issue-run',
+            runId: 'run-1',
+            namespace: 'default',
+            taskQueue: 'forge',
+            mode: 'managed-local',
+        });
+
+        await RefineIssueCommand.execute(
+            {} as vscode.ExtensionContext,
+            'https://github.com/alto9/forge/issues/77'
+        );
+
+        expect(mockedStartWorkflowRun).toHaveBeenCalledWith(
+            expect.objectContaining({
+                repositoryRoot: tempRoot,
+                workflowId: REFINE_ISSUE_WORKFLOW_ID,
+                submittedRunInputs: {
+                    issue_ref: 'https://github.com/alto9/forge/issues/77',
+                },
+            })
+        );
+    });
+
+    it('shows a diagnostic when repository inference fails for a bare issue number', async () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-refine-issue-command-'));
+
+        mockedResolveRepositoryFolder.mockResolvedValue({
+            uri: vscode.Uri.file(tempRoot),
+            name: 'unknown',
+            index: 0,
+        } as vscode.WorkspaceFolder);
+
+        await RefineIssueCommand.execute({} as vscode.ExtensionContext, '77');
+
+        expect(mockedStartWorkflowRun).not.toHaveBeenCalled();
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            expect.stringContaining('Could not infer repository owner/name')
+        );
+    });
+
+    it('surfaces start-path validation failures without treating them as command parse errors', async () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-refine-issue-command-'));
+        fs.mkdirSync(path.join(tempRoot, '.ai'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.ai/project.json'),
+            JSON.stringify({ github_url: 'https://github.com/alto9/forge' })
+        );
+
+        mockedResolveRepositoryFolder.mockResolvedValue({
+            uri: vscode.Uri.file(tempRoot),
+            name: 'forge',
+            index: 0,
+        } as vscode.WorkspaceFolder);
+
+        mockedGetWorkflowRunRecoveryContext.mockReturnValue({
+            globalStoragePath: tempRoot,
+            windowId: 'window-test',
+            indexStore: {} as never,
+            log: vi.fn(),
+            createRecoveryClient: vi.fn(),
+            isReady: () => true,
+        });
+
+        mockedStartWorkflowRun.mockResolvedValue({
+            ok: false,
+            diagnostics: [
+                {
+                    code: 'forge.workflow.run_input.required',
+                    severity: 'error',
+                    path: '/run_inputs/issue_ref',
+                    message: 'Required run input "issue_ref" is missing or empty.',
+                    validator_id: 'forge.workflow.run_input',
+                },
+            ],
+        });
+
+        await RefineIssueCommand.execute(
+            {} as vscode.ExtensionContext,
+            'https://github.com/alto9/forge/issues/77'
+        );
+
+        expect(mockedStartWorkflowRun).toHaveBeenCalled();
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            'Required run input "issue_ref" is missing or empty.'
+        );
+    });
+
+    it('normalizes owner/repo#N before calling the generic start path', async () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-refine-issue-command-'));
+        fs.mkdirSync(path.join(tempRoot, '.ai'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.ai/project.json'),
+            JSON.stringify({ github_url: 'https://github.com/alto9/forge' })
+        );
+
+        mockedResolveRepositoryFolder.mockResolvedValue({
+            uri: vscode.Uri.file(tempRoot),
+            name: 'forge',
+            index: 0,
+        } as vscode.WorkspaceFolder);
+
+        mockedGetWorkflowRunRecoveryContext.mockReturnValue({
+            globalStoragePath: tempRoot,
+            windowId: 'window-test',
+            indexStore: {} as never,
+            log: vi.fn(),
+            createRecoveryClient: vi.fn(),
+            isReady: () => true,
+        });
+
+        mockedStartWorkflowRun.mockResolvedValue({
+            ok: true,
+            workflowId: 'refine-issue-run',
+            runId: 'run-1',
+            namespace: 'default',
+            taskQueue: 'forge',
+            mode: 'managed-local',
+        });
+
+        await RefineIssueCommand.execute({} as vscode.ExtensionContext, 'alto9/forge#77');
+
+        expect(mockedStartWorkflowRun).toHaveBeenCalledWith(
+            expect.objectContaining({
+                submittedRunInputs: {
+                    issue_ref: 'https://github.com/alto9/forge/issues/77',
+                },
+            })
+        );
+    });
+});

--- a/src/commands/RefineIssueCommand.ts
+++ b/src/commands/RefineIssueCommand.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+import { inferRepositoryFromRoot } from '../github/inferRepositoryFromRoot';
+import { parseRefineIssueRef } from '../github/parseRefineIssueRef';
+import { startWorkflowRun } from '../temporal/startWorkflowRun';
+import { getWorkflowRunRecoveryContext } from '../temporal/workflowRunRecoveryService';
+import { WorkflowCatalogCommand } from './WorkflowCatalogCommand';
+
+export const REFINE_ISSUE_WORKFLOW_ID = 'refine-issue';
+
+export class RefineIssueCommand {
+    static async execute(
+        context: vscode.ExtensionContext,
+        issueInput?: string
+    ): Promise<void> {
+        const folder = await WorkflowCatalogCommand.resolveRepositoryFolder(context);
+        if (!folder) {
+            return;
+        }
+
+        let rawInput = issueInput?.trim();
+        if (!rawInput) {
+            rawInput = await vscode.window.showInputBox({
+                prompt: 'GitHub issue reference for refine-issue',
+                placeHolder: 'https://github.com/alto9/forge/issues/77 or alto9/forge#77',
+            });
+        }
+
+        if (!rawInput?.trim()) {
+            return;
+        }
+
+        const parsed = parseRefineIssueRef({
+            rawInput,
+            inferredRepository: inferRepositoryFromRoot(folder.uri.fsPath),
+        });
+
+        if (!parsed.ok) {
+            const message =
+                parsed.diagnostics[0]?.message ??
+                'The refine-issue command could not parse the supplied issue reference.';
+            void vscode.window.showErrorMessage(message);
+            return;
+        }
+
+        const recoveryContext = getWorkflowRunRecoveryContext();
+        if (!recoveryContext) {
+            void vscode.window.showErrorMessage('Workflow run recovery is not initialized.');
+            return;
+        }
+
+        const outcome = await startWorkflowRun({
+            repositoryRoot: folder.uri.fsPath,
+            workflowId: REFINE_ISSUE_WORKFLOW_ID,
+            submittedRunInputs: {
+                issue_ref: parsed.issueRef,
+            },
+            globalStoragePath: recoveryContext.globalStoragePath,
+            windowId: recoveryContext.windowId,
+            indexStore: recoveryContext.indexStore,
+            startedBy: 'refine-issue-command',
+        });
+
+        if (!outcome.ok) {
+            const message =
+                outcome.diagnostics[0]?.message ??
+                'Failed to start refine-issue through the generic workflow Start Run path.';
+            void vscode.window.showErrorMessage(message);
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { InitializeAgentsCommand } from './commands/InitializeAgentsCommand';
 import { InitializeProjectCommand } from './commands/InitializeProjectCommand';
 import { RoadmapCommand } from './commands/RoadmapCommand';
+import { RefineIssueCommand } from './commands/RefineIssueCommand';
 import { WorkflowCatalogCommand } from './commands/WorkflowCatalogCommand';
 import { WorkflowGraphCommand } from './commands/WorkflowGraphCommand';
 import { QuestionPanelCommand } from './commands/QuestionPanelCommand';
@@ -191,6 +192,14 @@ export function activate(context: vscode.ExtensionContext) {
         await RoadmapCommand.execute(context);
     });
     context.subscriptions.push(roadmapCommand);
+
+    const refineIssueCommand = vscode.commands.registerCommand(
+        'forge.refineIssue',
+        async (issueInput?: string) => {
+            await RefineIssueCommand.execute(context, issueInput);
+        }
+    );
+    context.subscriptions.push(refineIssueCommand);
 
     const openWorkflowCatalogCommand = vscode.commands.registerCommand(
         'forge.openWorkflowCatalog',

--- a/src/github/inferRepositoryFromRoot.test.ts
+++ b/src/github/inferRepositoryFromRoot.test.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { inferRepositoryFromRoot } from '../github/inferRepositoryFromRoot';
+
+describe('inferRepositoryFromRoot', () => {
+    let tempRoot: string;
+
+    afterEach(() => {
+        if (tempRoot && fs.existsSync(tempRoot)) {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+
+    it('reads owner/repo from .ai/project.json github_url', () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-infer-repo-'));
+        fs.mkdirSync(path.join(tempRoot, '.ai'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.ai/project.json'),
+            JSON.stringify({ github_url: 'https://github.com/alto9/forge' })
+        );
+
+        expect(inferRepositoryFromRoot(tempRoot)).toEqual({
+            owner: 'alto9',
+            repo: 'forge',
+        });
+    });
+
+    it('returns undefined when no repository context can be resolved', () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-infer-repo-'));
+
+        expect(inferRepositoryFromRoot(tempRoot)).toBeUndefined();
+    });
+});

--- a/src/github/inferRepositoryFromRoot.ts
+++ b/src/github/inferRepositoryFromRoot.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { parseGithubRepoUrl } from './projectBoardUrl';
+
+const PROJECT_JSON_RELATIVE_PATHS = ['.ai/project.json', '.forge/project.json'] as const;
+
+function readGithubUrlFromProjectJson(repositoryRoot: string): string | undefined {
+    for (const relativePath of PROJECT_JSON_RELATIVE_PATHS) {
+        const projectJsonPath = path.join(repositoryRoot, relativePath);
+        if (!fs.existsSync(projectJsonPath)) {
+            continue;
+        }
+
+        try {
+            const parsed = JSON.parse(fs.readFileSync(projectJsonPath, 'utf8')) as {
+                github_url?: unknown;
+            };
+            if (typeof parsed.github_url === 'string' && parsed.github_url.trim()) {
+                return parsed.github_url.trim();
+            }
+        } catch {
+            continue;
+        }
+    }
+
+    return undefined;
+}
+
+function readOriginRemoteUrl(repositoryRoot: string): string | undefined {
+    try {
+        const remoteUrl = execFileSync(
+            'git',
+            ['-C', repositoryRoot, 'remote', 'get-url', 'origin'],
+            { encoding: 'utf8' }
+        ).trim();
+
+        return remoteUrl || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function parseGitRemoteUrl(remoteUrl: string): { owner: string; repo: string } | undefined {
+    const sshMatch = remoteUrl.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/i);
+    if (sshMatch) {
+        return { owner: sshMatch[1], repo: sshMatch[2] };
+    }
+
+    if (/github\.com/i.test(remoteUrl)) {
+        try {
+            return parseGithubRepoUrl(remoteUrl);
+        } catch {
+            return undefined;
+        }
+    }
+
+    return undefined;
+}
+
+export function inferRepositoryFromRoot(
+    repositoryRoot: string
+): { owner: string; repo: string } | undefined {
+    const projectGithubUrl = readGithubUrlFromProjectJson(repositoryRoot);
+    if (projectGithubUrl) {
+        try {
+            return parseGithubRepoUrl(projectGithubUrl);
+        } catch {
+            // Fall through to git remote inference.
+        }
+    }
+
+    const remoteUrl = readOriginRemoteUrl(repositoryRoot);
+    if (!remoteUrl) {
+        return undefined;
+    }
+
+    return parseGitRemoteUrl(remoteUrl);
+}

--- a/src/github/parseRefineIssueRef.test.ts
+++ b/src/github/parseRefineIssueRef.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { parseRefineIssueRef } from '../github/parseRefineIssueRef';
+
+describe('parseRefineIssueRef', () => {
+    it('accepts a full GitHub issue URL', () => {
+        const result = parseRefineIssueRef({
+            rawInput: 'https://github.com/alto9/forge/issues/77',
+        });
+
+        expect(result).toEqual({
+            ok: true,
+            issueRef: 'https://github.com/alto9/forge/issues/77',
+        });
+    });
+
+    it('normalizes owner/repo#N to a full issue URL', () => {
+        const result = parseRefineIssueRef({
+            rawInput: 'alto9/forge#77',
+        });
+
+        expect(result).toEqual({
+            ok: true,
+            issueRef: 'https://github.com/alto9/forge/issues/77',
+        });
+    });
+
+    it('builds a full issue URL from a bare issue number when repository context is inferred', () => {
+        const result = parseRefineIssueRef({
+            rawInput: '77',
+            inferredRepository: { owner: 'alto9', repo: 'forge' },
+        });
+
+        expect(result).toEqual({
+            ok: true,
+            issueRef: 'https://github.com/alto9/forge/issues/77',
+        });
+    });
+
+    it('rejects a bare issue number when repository context cannot be inferred', () => {
+        const result = parseRefineIssueRef({
+            rawInput: '77',
+        });
+
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+            return;
+        }
+
+        expect(result.diagnostics[0]?.code).toBe('github.repository_inference_failed');
+    });
+
+    it('accepts a GitHub Projects v2 project identifier plus issue number', () => {
+        const result = parseRefineIssueRef({
+            rawInput: 'https://github.com/orgs/alto9/projects/9#77',
+        });
+
+        expect(result).toEqual({
+            ok: true,
+            issueRef: 'https://github.com/orgs/alto9/projects/9#77',
+        });
+    });
+
+    it('rejects empty input', () => {
+        const result = parseRefineIssueRef({
+            rawInput: '   ',
+        });
+
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+            return;
+        }
+
+        expect(result.diagnostics[0]?.code).toBe('github.issue_number_missing');
+    });
+
+    it('rejects malformed GitHub issue URLs', () => {
+        const result = parseRefineIssueRef({
+            rawInput: 'https://github.com/alto9/forge/issues/not-a-number',
+        });
+
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+            return;
+        }
+
+        expect(result.diagnostics[0]?.code).toBe('github.issue_url_unresolved');
+    });
+});

--- a/src/github/parseRefineIssueRef.ts
+++ b/src/github/parseRefineIssueRef.ts
@@ -1,0 +1,150 @@
+import type { Diagnostic } from '../workflows/types';
+import { parseProjectBoardUrl } from './projectBoardUrl';
+
+export type ParseRefineIssueRefResult =
+    | {
+          ok: true;
+          issueRef: string;
+      }
+    | {
+          ok: false;
+          diagnostics: Diagnostic[];
+      };
+
+const OWNER_REPO_HASH_PATTERN = /^([^/\s#]+)\/([^/\s#]+)#(\d+)$/;
+const BARE_ISSUE_NUMBER_PATTERN = /^(\d+)$/;
+const FULL_ISSUE_URL_PATTERN = /^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\/?(?:[?#].*)?$/i;
+const PROJECT_ISSUE_PATTERN =
+    /^(https?:\/\/github\.com\/(?:orgs|users)\/[^/]+\/projects\/\d+)#(\d+)$/i;
+
+function buildDiagnostic(
+    code: string,
+    message: string,
+    pathValue = 'issue_ref'
+): Diagnostic {
+    return {
+        code,
+        severity: 'error',
+        path: pathValue,
+        message,
+        validator_id: 'forge.refine_issue.command_entry',
+    };
+}
+
+function buildFullIssueUrl(owner: string, repo: string, issueNumber: string): string {
+    return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+}
+
+function parseProjectIssueRef(rawInput: string): ParseRefineIssueRefResult | undefined {
+    const match = rawInput.match(PROJECT_ISSUE_PATTERN);
+    if (!match) {
+        return undefined;
+    }
+
+    const [, projectUrl, issueNumber] = match;
+    try {
+        parseProjectBoardUrl(projectUrl);
+    } catch {
+        return {
+            ok: false,
+            diagnostics: [
+                buildDiagnostic(
+                    'github.project_unavailable',
+                    'The project identifier could not be parsed from the supplied issue reference.'
+                ),
+            ],
+        };
+    }
+
+    return {
+        ok: true,
+        issueRef: `${projectUrl}#${issueNumber}`,
+    };
+}
+
+export function parseRefineIssueRef(input: {
+    rawInput: string;
+    inferredRepository?: { owner: string; repo: string };
+}): ParseRefineIssueRefResult {
+    const trimmed = input.rawInput.trim();
+    if (!trimmed) {
+        return {
+            ok: false,
+            diagnostics: [
+                buildDiagnostic(
+                    'github.issue_number_missing',
+                    'A GitHub issue reference is required for refine-issue.'
+                ),
+            ],
+        };
+    }
+
+    const fullUrlMatch = trimmed.match(FULL_ISSUE_URL_PATTERN);
+    if (fullUrlMatch) {
+        const [, owner, repo, issueNumber] = fullUrlMatch;
+        return {
+            ok: true,
+            issueRef: buildFullIssueUrl(owner, repo, issueNumber),
+        };
+    }
+
+    const projectIssue = parseProjectIssueRef(trimmed);
+    if (projectIssue) {
+        return projectIssue;
+    }
+
+    const ownerRepoMatch = trimmed.match(OWNER_REPO_HASH_PATTERN);
+    if (ownerRepoMatch) {
+        const [, owner, repo, issueNumber] = ownerRepoMatch;
+        return {
+            ok: true,
+            issueRef: buildFullIssueUrl(owner, repo, issueNumber),
+        };
+    }
+
+    const bareNumberMatch = trimmed.match(BARE_ISSUE_NUMBER_PATTERN);
+    if (bareNumberMatch) {
+        if (!input.inferredRepository) {
+            return {
+                ok: false,
+                diagnostics: [
+                    buildDiagnostic(
+                        'github.repository_inference_failed',
+                        'Could not infer repository owner/name for a bare issue number. Use a full issue URL or owner/repo#N.'
+                    ),
+                ],
+            };
+        }
+
+        return {
+            ok: true,
+            issueRef: buildFullIssueUrl(
+                input.inferredRepository.owner,
+                input.inferredRepository.repo,
+                bareNumberMatch[1]
+            ),
+        };
+    }
+
+    if (/github\.com/i.test(trimmed) && /\/issues\//i.test(trimmed)) {
+        return {
+            ok: false,
+            diagnostics: [
+                buildDiagnostic(
+                    'github.issue_url_unresolved',
+                    'The supplied GitHub issue URL could not be parsed.'
+                ),
+            ],
+        };
+    }
+
+    return {
+        ok: false,
+        diagnostics: [
+            buildDiagnostic(
+                'github.issue_url_unresolved',
+                'The supplied issue reference is not a supported GitHub issue URL, owner/repo#N, project identifier, or bare issue number.'
+            ),
+        ],
+    };
+}


### PR DESCRIPTION
## Summary

- Add `Forge: Refine Issue` command entry that parses legacy issue reference forms (full URL, `owner/repo#N`, bare issue number with repo inference, and Projects v2 project identifier plus issue number).
- Submit normalized `run_inputs.issue_ref` through the existing generic `startWorkflowRun` path used by the workflow catalog.
- Keep parentage normalization and GitHub lookup in workflow activities; command layer is compatibility parsing only.

Closes #77

## Test plan

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] Added unit tests for issue reference parsing, repository inference, and command start wiring