### PR TITLE
Start a validated workflow run from the catalog (#78)

### DIFF
--- a/src/commands/RefineIssueCommand.ts
+++ b/src/commands/RefineIssueCommand.ts
@@ -56,7 +56,6 @@ export class RefineIssueCommand {
             },
             globalStoragePath: recoveryContext.globalStoragePath,
             windowId: recoveryContext.windowId,
-            indexStore: recoveryContext.indexStore,
             startedBy: 'refine-issue-command',
         });
 

--- a/src/commands/WorkflowCatalogCommand.ts
+++ b/src/commands/WorkflowCatalogCommand.ts
@@ -194,14 +194,15 @@ export class WorkflowCatalogCommand {
                     submittedRunInputs: runInputs,
                     globalStoragePath: recoveryContext.globalStoragePath,
                     windowId: recoveryContext.windowId,
-                    indexStore: recoveryContext.indexStore,
                 });
 
                 if (!outcome.ok) {
                     const firstDiagnostic = outcome.diagnostics[0];
                     return {
                         ok: false,
-                        message: firstDiagnostic?.message,
+                        message: outcome.inFlight
+                            ? 'Starting workflow run…'
+                            : firstDiagnostic?.message,
                     };
                 }
 

--- a/src/temporal/startWorkflowRun.test.ts
+++ b/src/temporal/startWorkflowRun.test.ts
@@ -2,36 +2,37 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { WorkflowRunIndexStore } from './workflowRunIndex';
 import {
     resetWorkflowStartInFlightGuardForTests,
 } from './workflowStartInFlightGuard';
 import { startWorkflowRun } from './startWorkflowRun';
 import type { TemporalWorkflowStartClient } from './startWorkflowRun';
-import { gateTemporalReadiness } from './temporalReadinessGate';
-import { gateWorkflowRunStart } from '../workflows/validateWorkflowForRun';
+import {
+    gateTemporalReadiness,
+    TemporalConfigurationInvalidError,
+} from './temporalReadinessGate';
+import { validateWorkflowForRun } from '../workflows/validateWorkflowForRun';
 
-vi.mock('./temporalReadinessGate', () => ({
-    gateTemporalReadiness: vi.fn(async () => undefined),
-}));
-
-vi.mock('../workflows/validateWorkflowForRun', () => ({
-    gateWorkflowRunStart: vi.fn(() => ({
-        valid: true,
-        diagnostics: [],
-        workflow_id: 'refine-issue',
-        path: '.ai/workflows/refine-issue.json',
-    })),
-}));
-
-function createIndexStore(): { store: WorkflowRunIndexStore; root: string; windowId: string } {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-start-run-index-'));
-    const windowId = `window-${path.basename(root)}`;
+vi.mock('./temporalReadinessGate', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./temporalReadinessGate')>();
     return {
-        store: new WorkflowRunIndexStore(root, windowId),
-        root,
-        windowId,
+        ...actual,
+        gateTemporalReadiness: vi.fn(async () => undefined),
     };
+});
+
+vi.mock('../workflows/validateWorkflowForRun', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../workflows/validateWorkflowForRun')>();
+    return {
+        ...actual,
+        validateWorkflowForRun: vi.fn(actual.validateWorkflowForRun),
+    };
+});
+
+function createTempGlobalStorage(): { root: string; windowId: string } {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-start-run-'));
+    const windowId = `window-${path.basename(root)}`;
+    return { root, windowId };
 }
 
 function createMockStartClient(): TemporalWorkflowStartClient {
@@ -63,8 +64,8 @@ afterEach(() => {
 });
 
 describe('startWorkflowRun', () => {
-    it('passes normalized run_inputs to Temporal and appends a run index entry', async () => {
-        const { store: indexStore, root, windowId } = createIndexStore();
+    it('passes normalized run_inputs to Temporal and returns Temporal identity', async () => {
+        const { root, windowId } = createTempGlobalStorage();
 
         const outcome = await startWorkflowRun({
             repositoryRoot: process.cwd(),
@@ -74,7 +75,6 @@ describe('startWorkflowRun', () => {
             },
             globalStoragePath: root,
             windowId,
-            indexStore,
             createStartClient: async () => createMockStartClient(),
             now: () => new Date('2026-06-11T12:00:00.000Z'),
         });
@@ -84,18 +84,21 @@ describe('startWorkflowRun', () => {
             return;
         }
 
-        expect(outcome.runId).toBe('run-test-1');
-        expect(outcome.startInputSummary).toContain('issue_ref:');
-        expect(gateWorkflowRunStart).toHaveBeenCalled();
-        expect(gateTemporalReadiness).toHaveBeenCalled();
-
-        const entries = indexStore.listEntries();
-        expect(entries).toHaveLength(1);
-        expect(entries[0]).toMatchObject({
-            workflow_id: 'refine-issue',
+        expect(outcome).toMatchObject({
             runId: 'run-test-1',
-            startInputSummary: expect.stringContaining('issue_ref:'),
+            namespace: expect.any(String),
+            taskQueue: expect.any(String),
+            mode: expect.any(String),
+            definitionVersion: expect.any(String),
+            repositoryRoot: process.cwd(),
+            run_inputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/75',
+            },
+            startedAt: '2026-06-11T12:00:00.000Z',
         });
+        expect(outcome.startInputSummary).toContain('issue_ref:');
+        expect(validateWorkflowForRun).toHaveBeenCalled();
+        expect(gateTemporalReadiness).toHaveBeenCalled();
 
         fs.rmSync(root, { recursive: true, force: true });
     });
@@ -116,7 +119,7 @@ describe('startWorkflowRun', () => {
             'utf8'
         );
 
-        const { store: indexStore, root, windowId } = createIndexStore();
+        const { root, windowId } = createTempGlobalStorage();
         const startClient = vi.fn(async () => ({
             async startWorkflow(input: {
                 args: [{ run_inputs: Record<string, string> }];
@@ -135,13 +138,13 @@ describe('startWorkflowRun', () => {
             submittedRunInputs: {},
             globalStoragePath: root,
             windowId,
-            indexStore,
             createStartClient: startClient,
         });
 
         expect(outcome).toEqual(
             expect.objectContaining({
                 ok: true,
+                runId: 'run-empty-1',
             })
         );
         expect(startClient).toHaveBeenCalled();
@@ -150,7 +153,7 @@ describe('startWorkflowRun', () => {
     });
 
     it('blocks before Temporal readiness when required run inputs are missing', async () => {
-        const { store: indexStore, root, windowId } = createIndexStore();
+        const { root, windowId } = createTempGlobalStorage();
         const startClient = vi.fn(async () => createMockStartClient());
 
         const outcome = await startWorkflowRun({
@@ -159,7 +162,6 @@ describe('startWorkflowRun', () => {
             submittedRunInputs: {},
             globalStoragePath: root,
             windowId,
-            indexStore,
             createStartClient: startClient,
         });
 
@@ -174,13 +176,12 @@ describe('startWorkflowRun', () => {
         });
         expect(gateTemporalReadiness).not.toHaveBeenCalled();
         expect(startClient).not.toHaveBeenCalled();
-        expect(indexStore.listEntries()).toEqual([]);
 
         fs.rmSync(root, { recursive: true, force: true });
     });
 
-    it('blocks undeclared submitted keys before Temporal start without creating run index state', async () => {
-        const { store: indexStore, root, windowId } = createIndexStore();
+    it('blocks undeclared submitted keys before Temporal start', async () => {
+        const { root, windowId } = createTempGlobalStorage();
         const startClient = vi.fn(async () => createMockStartClient());
         const secretValue = 'undeclared-secret-value-xyz';
 
@@ -193,7 +194,6 @@ describe('startWorkflowRun', () => {
             },
             globalStoragePath: root,
             windowId,
-            indexStore,
             createStartClient: startClient,
         });
 
@@ -213,7 +213,129 @@ describe('startWorkflowRun', () => {
         expect(JSON.stringify(outcome.diagnostics)).not.toContain(secretValue);
         expect(gateTemporalReadiness).not.toHaveBeenCalled();
         expect(startClient).not.toHaveBeenCalled();
-        expect(indexStore.listEntries()).toEqual([]);
+
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('returns readiness diagnostics instead of throwing when Temporal readiness fails', async () => {
+        const { root, windowId } = createTempGlobalStorage();
+        vi.mocked(gateTemporalReadiness).mockRejectedValueOnce(
+            new TemporalConfigurationInvalidError([
+                {
+                    code: 'forge.temporal.configuration_invalid',
+                    severity: 'error',
+                    path: 'forge.temporal.worker',
+                    message: 'Worker is not ready.',
+                    validator_id: 'forge.temporal.readiness',
+                },
+            ])
+        );
+
+        const outcome = await startWorkflowRun({
+            repositoryRoot: process.cwd(),
+            workflowId: 'refine-issue',
+            submittedRunInputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/75',
+            },
+            globalStoragePath: root,
+            windowId,
+            createStartClient: async () => createMockStartClient(),
+        });
+
+        expect(outcome).toEqual({
+            ok: false,
+            diagnostics: [
+                expect.objectContaining({
+                    code: 'forge.temporal.configuration_invalid',
+                    path: 'forge.temporal.worker',
+                }),
+            ],
+        });
+
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('blocks duplicate in-flight starts for the same workflow and payload', async () => {
+        const { root, windowId } = createTempGlobalStorage();
+        let resolveStart: (() => void) | undefined;
+        const startGate = new Promise<void>((resolve) => {
+            resolveStart = resolve;
+        });
+
+        vi.mocked(gateTemporalReadiness).mockImplementationOnce(async () => {
+            await startGate;
+        });
+
+        const firstStart = startWorkflowRun({
+            repositoryRoot: process.cwd(),
+            workflowId: 'refine-issue',
+            submittedRunInputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/75',
+            },
+            globalStoragePath: root,
+            windowId,
+            createStartClient: async () => createMockStartClient(),
+        });
+
+        const duplicate = await startWorkflowRun({
+            repositoryRoot: process.cwd(),
+            workflowId: 'refine-issue',
+            submittedRunInputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/75',
+            },
+            globalStoragePath: root,
+            windowId,
+            createStartClient: async () => createMockStartClient(),
+        });
+
+        expect(duplicate).toEqual({
+            ok: false,
+            inFlight: true,
+            diagnostics: [
+                expect.objectContaining({
+                    code: 'forge.workflow.start_in_flight',
+                }),
+            ],
+        });
+
+        resolveStart?.();
+        await firstStart;
+
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('returns definition validation diagnostics without calling Temporal readiness', async () => {
+        const { root, windowId } = createTempGlobalStorage();
+        vi.mocked(validateWorkflowForRun).mockReturnValueOnce({
+            valid: false,
+            diagnostics: [
+                {
+                    code: 'forge.workflow.schema_invalid',
+                    severity: 'error',
+                    path: '.ai/workflows/broken.json',
+                    message: 'Schema validation failed.',
+                    validator_id: 'forge.workflow.schema',
+                },
+            ],
+            workflow_id: 'broken',
+            path: '.ai/workflows/broken.json',
+        });
+
+        const outcome = await startWorkflowRun({
+            repositoryRoot: process.cwd(),
+            workflowId: 'broken',
+            submittedRunInputs: {},
+            globalStoragePath: root,
+            windowId,
+        });
+
+        expect(outcome.ok).toBe(false);
+        if (outcome.ok) {
+            return;
+        }
+
+        expect(outcome.diagnostics[0]?.code).toBe('forge.workflow.schema_invalid');
+        expect(gateTemporalReadiness).not.toHaveBeenCalled();
 
         fs.rmSync(root, { recursive: true, force: true });
     });

--- a/src/temporal/startWorkflowRun.ts
+++ b/src/temporal/startWorkflowRun.ts
@@ -6,14 +6,17 @@ import {
     validateSubmittedRunInputs,
     WORKFLOW_RUN_INPUT_VALIDATOR_ID,
 } from '../workflows/validateSubmittedRunInputs';
-import { gateWorkflowRunStart } from '../workflows/validateWorkflowForRun';
+import { validateWorkflowForRun } from '../workflows/validateWorkflowForRun';
 import type {
     Diagnostic,
     WorkflowRunStartInput,
     WorkflowRunStartPayload,
 } from '../workflows/types';
 import { loadWorkflowDefinition } from '../workflows/loadWorkflowDefinition';
-import { gateTemporalReadiness } from './temporalReadinessGate';
+import {
+    gateTemporalReadiness,
+    TemporalConfigurationInvalidError,
+} from './temporalReadinessGate';
 import { formatSafeForLog } from './secretRedaction';
 import { resolveTemporalMode } from './temporalSettings';
 import { resolveManagedLocalSettings } from './managedLocalSettings';
@@ -26,8 +29,6 @@ import {
     tryAcquireWorkflowStartInFlight,
 } from './workflowStartInFlightGuard';
 import { isKnownTemporalWorkflowType, resolveTemporalWorkflowType } from './workflowTypeRegistry';
-import { notifyWorkflowRunIndexChanged } from './workflowRunRecoveryService';
-import type { WorkflowRunIndexStore } from './workflowRunIndex';
 import type { TemporalMode } from './temporalSettings';
 
 export const WORKFLOW_START_IN_FLIGHT_VALIDATOR_ID = 'forge.workflow.start_in_flight';
@@ -48,7 +49,6 @@ export interface StartWorkflowRunInput {
     submittedRunInputs?: Record<string, unknown>;
     globalStoragePath: string;
     windowId: string;
-    indexStore: WorkflowRunIndexStore;
     startedBy?: string;
     createStartClient?: () => Promise<TemporalWorkflowStartClient>;
     now?: () => Date;
@@ -62,7 +62,12 @@ export type StartWorkflowRunOutcome =
           namespace: string;
           taskQueue: string;
           mode: TemporalMode;
+          definitionVersion: string;
+          repositoryRoot: string;
+          run_inputs: WorkflowRunStartInput;
+          startedAt: string;
           startInputSummary?: string;
+          started_by?: string;
       }
     | {
           ok: false;
@@ -154,10 +159,14 @@ export async function startWorkflowRun(input: StartWorkflowRunInput): Promise<St
     const workflowId = input.workflowId;
     const submitted = input.submittedRunInputs ?? {};
 
-    gateWorkflowRunStart({
+    const definitionValidation = validateWorkflowForRun({
         workspaceRoots: [repositoryRoot],
         workflowId,
     });
+
+    if (!definitionValidation.valid) {
+        return { ok: false, diagnostics: definitionValidation.diagnostics };
+    }
 
     const definition = loadWorkflowDefinition(repositoryRoot, workflowId);
     if (!definition) {
@@ -204,8 +213,6 @@ export async function startWorkflowRun(input: StartWorkflowRunInput): Promise<St
         };
     }
 
-    await gateTemporalReadiness();
-
     const inFlightKey = buildWorkflowStartInFlightKey(
         workflowId,
         repositoryRoot,
@@ -228,76 +235,78 @@ export async function startWorkflowRun(input: StartWorkflowRunInput): Promise<St
         };
     }
 
-    const connection = resolveTemporalConnection(input.globalStoragePath, input.windowId);
-    const temporalWorkflowType = resolveTemporalWorkflowType(workflowId)!;
-    const temporalWorkflowId = buildTemporalWorkflowId(workflowId);
-    const startedAt = (input.now ?? (() => new Date()))().toISOString();
-
-    const payload: WorkflowRunStartPayload = {
-        workflow_id: workflowId,
-        definition_version: definition.version,
-        repositoryRoot,
-        run_inputs: normalizedRunInputs,
-        started_at: startedAt,
-        ...(input.startedBy ? { started_by: input.startedBy } : {}),
-    };
-
-    const startClient =
-        input.createStartClient ??
-        (() => createTemporalWorkflowStartClient(input.globalStoragePath, input.windowId));
-
     try {
-        const client = await startClient();
         try {
-            const started = await client.startWorkflow({
-                workflowType: temporalWorkflowType,
-                workflowId: temporalWorkflowId,
-                taskQueue: connection.taskQueue,
-                args: [payload],
-            });
-
-            const startInputSummary = buildStartInputSummary(declarations, normalizedRunInputs);
-
-            input.indexStore.appendRunStartEntry({
-                namespace: connection.namespace,
-                workflowId: started.workflowId,
-                runId: started.runId,
-                taskQueue: connection.taskQueue,
-                workflow_id: workflowId,
-                repositoryRoot,
-                mode: connection.mode,
-                startedAt,
-                ...(startInputSummary ? { startInputSummary } : {}),
-            });
-
-            notifyWorkflowRunIndexChanged();
-
-            return {
-                ok: true,
-                workflowId: started.workflowId,
-                runId: started.runId,
-                namespace: connection.namespace,
-                taskQueue: connection.taskQueue,
-                mode: connection.mode,
-                startInputSummary,
-            };
-        } finally {
-            await client.close();
+            await gateTemporalReadiness();
+        } catch (error) {
+            if (error instanceof TemporalConfigurationInvalidError) {
+                return { ok: false, diagnostics: error.diagnostics };
+            }
+            throw error;
         }
-    } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-            ok: false,
-            diagnostics: [
-                {
-                    code: 'forge.temporal.start_failed',
-                    severity: 'error',
-                    path: 'forge.temporal',
-                    message: formatSafeForLog(message),
-                    validator_id: 'forge.temporal.readiness',
-                },
-            ],
+
+        const connection = resolveTemporalConnection(input.globalStoragePath, input.windowId);
+        const temporalWorkflowType = resolveTemporalWorkflowType(workflowId)!;
+        const temporalWorkflowId = buildTemporalWorkflowId(workflowId);
+        const startedAt = (input.now ?? (() => new Date()))().toISOString();
+
+        const payload: WorkflowRunStartPayload = {
+            workflow_id: workflowId,
+            definition_version: definition.version,
+            repositoryRoot,
+            run_inputs: normalizedRunInputs,
+            started_at: startedAt,
+            ...(input.startedBy ? { started_by: input.startedBy } : {}),
         };
+
+        const startClient =
+            input.createStartClient ??
+            (() => createTemporalWorkflowStartClient(input.globalStoragePath, input.windowId));
+
+        try {
+            const client = await startClient();
+            try {
+                const started = await client.startWorkflow({
+                    workflowType: temporalWorkflowType,
+                    workflowId: temporalWorkflowId,
+                    taskQueue: connection.taskQueue,
+                    args: [payload],
+                });
+
+                const startInputSummary = buildStartInputSummary(declarations, normalizedRunInputs);
+
+                return {
+                    ok: true,
+                    workflowId: started.workflowId,
+                    runId: started.runId,
+                    namespace: connection.namespace,
+                    taskQueue: connection.taskQueue,
+                    mode: connection.mode,
+                    definitionVersion: definition.version,
+                    repositoryRoot,
+                    run_inputs: normalizedRunInputs,
+                    startedAt,
+                    startInputSummary,
+                    ...(input.startedBy ? { started_by: input.startedBy } : {}),
+                };
+            } finally {
+                await client.close();
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return {
+                ok: false,
+                diagnostics: [
+                    {
+                        code: 'forge.temporal.start_failed',
+                        severity: 'error',
+                        path: 'forge.temporal',
+                        message: formatSafeForLog(message),
+                        validator_id: 'forge.temporal.readiness',
+                    },
+                ],
+            };
+        }
     } finally {
         releaseWorkflowStartInFlight(inFlightKey);
     }


### PR DESCRIPTION
## Summary

- Route catalog and refine-issue Start Run through a single `startWorkflowRun` orchestration path that validates definition, run inputs, Temporal readiness, and worker readiness before calling Temporal start.
- Return structured diagnostics for blocked starts (including duplicate in-flight suppression) instead of throwing, and acquire the in-flight guard before readiness so parallel clicks are suppressed during the full start request.
- Stop appending run-index entries from orchestration so #79 can persist Temporal identity from the returned success result; catalog surfaces in-flight feedback for duplicate attempts.

Fixes #78

## Test plan

- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm test` (479 tests, including start orchestration, readiness failure, in-flight guard, and run input validation coverage)
- [x] `npm run build`
- [ ] Manual: Forge dev host → Open Workflow Catalog → Start Run with valid/invalid inputs, undeclared keys, Temporal/worker not ready, and duplicate in-flight clicks