### PR TITLE
Persist Temporal run identity into the window run index

### DIFF
--- a/src/commands/RefineIssueCommand.test.ts
+++ b/src/commands/RefineIssueCommand.test.ts
@@ -4,12 +4,17 @@ import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RefineIssueCommand, REFINE_ISSUE_WORKFLOW_ID } from '../commands/RefineIssueCommand';
 import { WorkflowCatalogCommand } from '../commands/WorkflowCatalogCommand';
+import { persistAcceptedWorkflowRun } from '../temporal/persistAcceptedWorkflowRun';
 import { startWorkflowRun } from '../temporal/startWorkflowRun';
 import { getWorkflowRunRecoveryContext } from '../temporal/workflowRunRecoveryService';
 import * as vscode from 'vscode';
 
 vi.mock('../temporal/startWorkflowRun', () => ({
     startWorkflowRun: vi.fn(),
+}));
+
+vi.mock('../temporal/persistAcceptedWorkflowRun', () => ({
+    persistAcceptedWorkflowRun: vi.fn(),
 }));
 
 vi.mock('../temporal/workflowRunRecoveryService', () => ({
@@ -23,6 +28,7 @@ vi.mock('../commands/WorkflowCatalogCommand', () => ({
 }));
 
 const mockedStartWorkflowRun = vi.mocked(startWorkflowRun);
+const mockedPersistAcceptedWorkflowRun = vi.mocked(persistAcceptedWorkflowRun);
 const mockedGetWorkflowRunRecoveryContext = vi.mocked(getWorkflowRunRecoveryContext);
 const mockedResolveRepositoryFolder = vi.mocked(WorkflowCatalogCommand.resolveRepositoryFolder);
 
@@ -65,7 +71,17 @@ describe('RefineIssueCommand', () => {
             runId: 'run-1',
             namespace: 'default',
             taskQueue: 'forge',
-            mode: 'managed-local',
+            mode: 'managedLocal',
+            definitionVersion: '1.0.0',
+            repositoryRoot: tempRoot,
+            run_inputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/77',
+            },
+            startedAt: '2026-06-11T12:00:00.000Z',
+        });
+        mockedPersistAcceptedWorkflowRun.mockReturnValue({
+            ok: true,
+            indexKey: 'default:refine-issue-run:run-1',
         });
 
         await RefineIssueCommand.execute(
@@ -80,6 +96,11 @@ describe('RefineIssueCommand', () => {
                 submittedRunInputs: {
                     issue_ref: 'https://github.com/alto9/forge/issues/77',
                 },
+            })
+        );
+        expect(mockedPersistAcceptedWorkflowRun).toHaveBeenCalledWith(
+            expect.objectContaining({
+                workflow_id: REFINE_ISSUE_WORKFLOW_ID,
             })
         );
     });
@@ -177,7 +198,17 @@ describe('RefineIssueCommand', () => {
             runId: 'run-1',
             namespace: 'default',
             taskQueue: 'forge',
-            mode: 'managed-local',
+            mode: 'managedLocal',
+            definitionVersion: '1.0.0',
+            repositoryRoot: tempRoot,
+            run_inputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/77',
+            },
+            startedAt: '2026-06-11T12:00:00.000Z',
+        });
+        mockedPersistAcceptedWorkflowRun.mockReturnValue({
+            ok: true,
+            indexKey: 'default:refine-issue-run:run-1',
         });
 
         await RefineIssueCommand.execute({} as vscode.ExtensionContext, 'alto9/forge#77');
@@ -188,6 +219,68 @@ describe('RefineIssueCommand', () => {
                     issue_ref: 'https://github.com/alto9/forge/issues/77',
                 },
             })
+        );
+    });
+
+    it('surfaces post-start index persistence failures without starting Temporal again', async () => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-refine-issue-command-'));
+        fs.mkdirSync(path.join(tempRoot, '.ai'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.ai/project.json'),
+            JSON.stringify({ github_url: 'https://github.com/alto9/forge' })
+        );
+
+        mockedResolveRepositoryFolder.mockResolvedValue({
+            uri: vscode.Uri.file(tempRoot),
+            name: 'forge',
+            index: 0,
+        } as vscode.WorkspaceFolder);
+
+        mockedGetWorkflowRunRecoveryContext.mockReturnValue({
+            globalStoragePath: tempRoot,
+            windowId: 'window-test',
+            indexStore: {} as never,
+            log: vi.fn(),
+            createRecoveryClient: vi.fn(),
+            isReady: () => true,
+        });
+
+        mockedStartWorkflowRun.mockResolvedValue({
+            ok: true,
+            workflowId: 'refine-issue-run',
+            runId: 'run-1',
+            namespace: 'default',
+            taskQueue: 'forge',
+            mode: 'managedLocal',
+            definitionVersion: '1.0.0',
+            repositoryRoot: tempRoot,
+            run_inputs: {
+                issue_ref: 'https://github.com/alto9/forge/issues/77',
+            },
+            startedAt: '2026-06-11T12:00:00.000Z',
+        });
+        mockedPersistAcceptedWorkflowRun.mockReturnValue({
+            ok: false,
+            diagnostics: [
+                {
+                    code: 'forge.workflow.run_index.write_failed',
+                    severity: 'error',
+                    path: 'forge.workflow.run_index',
+                    message:
+                        'Workflow run started in Temporal, but Forge could not save the local run index. List, graph, cancel, and recovery actions are unavailable until the run is indexed.',
+                    validator_id: 'forge.workflow.run_index',
+                },
+            ],
+        });
+
+        await RefineIssueCommand.execute(
+            {} as vscode.ExtensionContext,
+            'https://github.com/alto9/forge/issues/77'
+        );
+
+        expect(mockedStartWorkflowRun).toHaveBeenCalledTimes(1);
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            expect.stringContaining('could not save the local run index')
         );
     });
 });

--- a/src/commands/RefineIssueCommand.ts
+++ b/src/commands/RefineIssueCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { inferRepositoryFromRoot } from '../github/inferRepositoryFromRoot';
 import { parseRefineIssueRef } from '../github/parseRefineIssueRef';
+import { persistAcceptedWorkflowRun } from '../temporal/persistAcceptedWorkflowRun';
 import { startWorkflowRun } from '../temporal/startWorkflowRun';
 import { getWorkflowRunRecoveryContext } from '../temporal/workflowRunRecoveryService';
 import { WorkflowCatalogCommand } from './WorkflowCatalogCommand';
@@ -63,6 +64,21 @@ export class RefineIssueCommand {
             const message =
                 outcome.diagnostics[0]?.message ??
                 'Failed to start refine-issue through the generic workflow Start Run path.';
+            void vscode.window.showErrorMessage(message);
+            return;
+        }
+
+        const persistOutcome = persistAcceptedWorkflowRun({
+            workflow_id: REFINE_ISSUE_WORKFLOW_ID,
+            startOutcome: outcome,
+            indexStore: recoveryContext.indexStore,
+            log: recoveryContext.log,
+        });
+
+        if (!persistOutcome.ok) {
+            const message =
+                persistOutcome.diagnostics[0]?.message ??
+                'Workflow run started in Temporal, but Forge could not save the local run index.';
             void vscode.window.showErrorMessage(message);
         }
     }

--- a/src/commands/WorkflowCatalogCommand.ts
+++ b/src/commands/WorkflowCatalogCommand.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { persistAcceptedWorkflowRun } from '../temporal/persistAcceptedWorkflowRun';
 import { startWorkflowRun } from '../temporal/startWorkflowRun';
 import { getWorkflowRunRecoveryContext } from '../temporal/workflowRunRecoveryService';
 import { buildWorkflowCatalog } from '../workflows/buildWorkflowCatalog';
@@ -203,6 +204,25 @@ export class WorkflowCatalogCommand {
                         message: outcome.inFlight
                             ? 'Starting workflow run…'
                             : firstDiagnostic?.message,
+                    };
+                }
+
+                const persistOutcome = persistAcceptedWorkflowRun({
+                    workflow_id: workflowId,
+                    startOutcome: outcome,
+                    indexStore: recoveryContext.indexStore,
+                    log: recoveryContext.log,
+                });
+
+                if (!persistOutcome.ok) {
+                    const firstDiagnostic = persistOutcome.diagnostics[0];
+                    const message = firstDiagnostic?.message;
+                    if (message) {
+                        void vscode.window.showErrorMessage(message);
+                    }
+                    return {
+                        ok: false,
+                        message,
                     };
                 }
 

--- a/src/temporal/index.ts
+++ b/src/temporal/index.ts
@@ -144,6 +144,14 @@ export {
     createTemporalWorkflowStartClient,
     startWorkflowRun,
 } from './startWorkflowRun';
+export {
+    WORKFLOW_RUN_INDEX_VALIDATOR_ID,
+    persistAcceptedWorkflowRun,
+} from './persistAcceptedWorkflowRun';
+export type {
+    PersistAcceptedWorkflowRunInput,
+    PersistAcceptedWorkflowRunOutcome,
+} from './persistAcceptedWorkflowRun';
 export type {
     StartWorkflowRunInput,
     StartWorkflowRunOutcome,

--- a/src/temporal/persistAcceptedWorkflowRun.test.ts
+++ b/src/temporal/persistAcceptedWorkflowRun.test.ts
@@ -1,0 +1,191 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { persistAcceptedWorkflowRun } from './persistAcceptedWorkflowRun';
+import {
+    buildRunIndexKey,
+    readWorkflowRunIndexFile,
+    resolveRunIndexPath,
+    WorkflowRunIndexStore,
+} from './workflowRunIndex';
+import * as workflowRunRecoveryService from './workflowRunRecoveryService';
+import type { StartWorkflowRunOutcome } from './startWorkflowRun';
+
+function createTempGlobalStorage(): { globalStoragePath: string; windowId: string } {
+    const globalStoragePath = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-persist-run-'));
+    const windowId = `window-${path.basename(globalStoragePath)}`;
+    return { globalStoragePath, windowId };
+}
+
+function createSuccessfulStartOutcome(
+    overrides: Partial<Extract<StartWorkflowRunOutcome, { ok: true }>> = {}
+): Extract<StartWorkflowRunOutcome, { ok: true }> {
+    return {
+        ok: true,
+        workflowId: 'refine-issue-abc',
+        runId: 'run-test-1',
+        namespace: 'forge-local',
+        taskQueue: 'forge',
+        mode: 'managedLocal',
+        definitionVersion: '1.0.0',
+        repositoryRoot: '/repo/forge',
+        run_inputs: { issue_ref: 'https://github.com/alto9/forge/issues/79' },
+        startedAt: '2026-06-11T12:00:00.000Z',
+        startInputSummary: 'issue_ref: https://github.com/alto9/forge/issues/79',
+        ...overrides,
+    };
+}
+
+describe('persistAcceptedWorkflowRun', () => {
+    const tempRoots: string[] = [];
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        for (const root of tempRoots.splice(0)) {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('appends a recovery_pending entry and notifies the Workflow Runs view', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        tempRoots.push(globalStoragePath);
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const notifySpy = vi.spyOn(workflowRunRecoveryService, 'notifyWorkflowRunIndexChanged');
+
+        const outcome = persistAcceptedWorkflowRun({
+            workflow_id: 'refine-issue',
+            startOutcome: createSuccessfulStartOutcome(),
+            indexStore: store,
+        });
+
+        expect(outcome).toEqual({
+            ok: true,
+            indexKey: 'forge-local:refine-issue-abc:run-test-1',
+        });
+        expect(notifySpy).toHaveBeenCalledTimes(1);
+
+        const index = readWorkflowRunIndexFile(resolveRunIndexPath(globalStoragePath, windowId));
+        expect(index.entries['forge-local:refine-issue-abc:run-test-1']).toMatchObject({
+            namespace: 'forge-local',
+            workflowId: 'refine-issue-abc',
+            runId: 'run-test-1',
+            taskQueue: 'forge',
+            workflow_id: 'refine-issue',
+            repositoryRoot: '/repo/forge',
+            mode: 'managedLocal',
+            startedAt: '2026-06-11T12:00:00.000Z',
+            startInputSummary: 'issue_ref: https://github.com/alto9/forge/issues/79',
+            recoveryState: 'recovery_pending',
+            terminal: false,
+        });
+    });
+
+    it('does not append when the index already contains the Temporal identity key', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        tempRoots.push(globalStoragePath);
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const startOutcome = createSuccessfulStartOutcome();
+        const notifySpy = vi.spyOn(workflowRunRecoveryService, 'notifyWorkflowRunIndexChanged');
+        const logs: string[] = [];
+
+        store.appendRunStartEntry({
+            namespace: startOutcome.namespace,
+            workflowId: startOutcome.workflowId,
+            runId: startOutcome.runId,
+            taskQueue: startOutcome.taskQueue,
+            workflow_id: 'refine-issue',
+            repositoryRoot: startOutcome.repositoryRoot,
+            mode: startOutcome.mode,
+            startedAt: startOutcome.startedAt,
+        });
+        notifySpy.mockClear();
+
+        const outcome = persistAcceptedWorkflowRun({
+            workflow_id: 'refine-issue',
+            startOutcome,
+            indexStore: store,
+            log: (line) => logs.push(line),
+        });
+
+        expect(outcome.ok).toBe(false);
+        if (outcome.ok) {
+            return;
+        }
+
+        expect(outcome.diagnostics[0]).toMatchObject({
+            code: 'forge.workflow.run_index.duplicate_key',
+            validator_id: 'forge.workflow.run_index',
+        });
+        expect(notifySpy).not.toHaveBeenCalled();
+        expect(logs.join('\n')).toContain('workflowId=refine-issue-abc');
+        expect(logs.join('\n')).toContain('runId=run-test-1');
+
+        const index = readWorkflowRunIndexFile(resolveRunIndexPath(globalStoragePath, windowId));
+        expect(Object.keys(index.entries)).toHaveLength(1);
+    });
+
+    it('reports a post-start diagnostic when index persistence fails after Temporal accepted the run', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        tempRoots.push(globalStoragePath);
+        const indexPath = resolveRunIndexPath(globalStoragePath, windowId);
+        fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+        fs.writeFileSync(indexPath, '{"version":1,"entries":{}}\n', 'utf8');
+        fs.chmodSync(path.dirname(indexPath), 0o555);
+
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const notifySpy = vi.spyOn(workflowRunRecoveryService, 'notifyWorkflowRunIndexChanged');
+        const logs: string[] = [];
+
+        const outcome = persistAcceptedWorkflowRun({
+            workflow_id: 'refine-issue',
+            startOutcome: createSuccessfulStartOutcome(),
+            indexStore: store,
+            log: (line) => logs.push(line),
+        });
+
+        fs.chmodSync(path.dirname(indexPath), 0o755);
+
+        expect(outcome.ok).toBe(false);
+        if (outcome.ok) {
+            return;
+        }
+
+        expect(outcome.diagnostics[0]).toMatchObject({
+            code: 'forge.workflow.run_index.write_failed',
+            validator_id: 'forge.workflow.run_index',
+        });
+        expect(notifySpy).not.toHaveBeenCalled();
+        expect(logs.join('\n')).toContain('taskQueue=forge');
+        expect(readWorkflowRunIndexFile(indexPath).entries).toEqual({});
+    });
+
+    it('exposes the indexed entry for recovery projection lookup by Temporal identity', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        tempRoots.push(globalStoragePath);
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const startOutcome = createSuccessfulStartOutcome({
+            workflowId: 'wf-recovery',
+            runId: 'run-recovery',
+            namespace: 'default',
+        });
+
+        const outcome = persistAcceptedWorkflowRun({
+            workflow_id: 'refine-issue',
+            startOutcome,
+            indexStore: store,
+        });
+
+        expect(outcome.ok).toBe(true);
+        if (!outcome.ok) {
+            return;
+        }
+
+        const key = buildRunIndexKey('default', 'wf-recovery', 'run-recovery');
+        expect(store.getEntry(key)).toMatchObject({
+            workflow_id: 'refine-issue',
+            recoveryState: 'recovery_pending',
+            terminal: false,
+        });
+    });
+});

--- a/src/temporal/persistAcceptedWorkflowRun.ts
+++ b/src/temporal/persistAcceptedWorkflowRun.ts
@@ -1,0 +1,123 @@
+import type { Diagnostic } from '../workflows/types';
+import type { StartWorkflowRunOutcome } from './startWorkflowRun';
+import {
+    RunIndexDuplicateKeyError,
+    WorkflowRunIndexStore,
+    buildRunIndexKey,
+} from './workflowRunIndex';
+import { notifyWorkflowRunIndexChanged } from './workflowRunRecoveryService';
+
+export const WORKFLOW_RUN_INDEX_VALIDATOR_ID = 'forge.workflow.run_index';
+
+export interface PersistAcceptedWorkflowRunInput {
+    workflow_id: string;
+    startOutcome: Extract<StartWorkflowRunOutcome, { ok: true }>;
+    indexStore: WorkflowRunIndexStore;
+    log?: (line: string) => void;
+}
+
+export type PersistAcceptedWorkflowRunOutcome =
+    | { ok: true; indexKey: string }
+    | { ok: false; diagnostics: Diagnostic[] };
+
+function buildPostStartIndexLogLine(input: {
+    workflow_id: string;
+    namespace: string;
+    workflowId: string;
+    runId: string;
+    taskQueue: string;
+    code: string;
+    message: string;
+}): string {
+    return [
+        '[forge.workflow.run_index]',
+        `code=${input.code}`,
+        `workflow_id=${input.workflow_id}`,
+        `namespace=${input.namespace}`,
+        `workflowId=${input.workflowId}`,
+        `runId=${input.runId}`,
+        `taskQueue=${input.taskQueue}`,
+        `message=${input.message}`,
+    ].join(' ');
+}
+
+function buildDuplicateKeyDiagnostic(): Diagnostic {
+    return {
+        code: 'forge.workflow.run_index.duplicate_key',
+        severity: 'error',
+        path: 'forge.workflow.run_index',
+        message:
+            'Workflow run started in Temporal, but this run is already indexed. Local list, graph, cancel, and recovery actions use the existing entry.',
+        validator_id: WORKFLOW_RUN_INDEX_VALIDATOR_ID,
+    };
+}
+
+function buildWriteFailedDiagnostic(): Diagnostic {
+    return {
+        code: 'forge.workflow.run_index.write_failed',
+        severity: 'error',
+        path: 'forge.workflow.run_index',
+        message:
+            'Workflow run started in Temporal, but Forge could not save the local run index. List, graph, cancel, and recovery actions are unavailable until the run is indexed.',
+        validator_id: WORKFLOW_RUN_INDEX_VALIDATOR_ID,
+    };
+}
+
+export function persistAcceptedWorkflowRun(
+    input: PersistAcceptedWorkflowRunInput
+): PersistAcceptedWorkflowRunOutcome {
+    const startOutcome = input.startOutcome;
+
+    try {
+        const entry = input.indexStore.appendRunStartEntry({
+            namespace: startOutcome.namespace,
+            workflowId: startOutcome.workflowId,
+            runId: startOutcome.runId,
+            taskQueue: startOutcome.taskQueue,
+            workflow_id: input.workflow_id,
+            repositoryRoot: startOutcome.repositoryRoot,
+            mode: startOutcome.mode,
+            startedAt: startOutcome.startedAt,
+            ...(startOutcome.startInputSummary
+                ? { startInputSummary: startOutcome.startInputSummary }
+                : {}),
+        });
+
+        notifyWorkflowRunIndexChanged();
+
+        return {
+            ok: true,
+            indexKey: buildRunIndexKey(entry.namespace, entry.workflowId, entry.runId),
+        };
+    } catch (error) {
+        if (error instanceof RunIndexDuplicateKeyError) {
+            const diagnostic = buildDuplicateKeyDiagnostic();
+            input.log?.(
+                buildPostStartIndexLogLine({
+                    workflow_id: input.workflow_id,
+                    namespace: startOutcome.namespace,
+                    workflowId: startOutcome.workflowId,
+                    runId: startOutcome.runId,
+                    taskQueue: startOutcome.taskQueue,
+                    code: diagnostic.code,
+                    message: diagnostic.message,
+                })
+            );
+            return { ok: false, diagnostics: [diagnostic] };
+        }
+
+        const diagnostic = buildWriteFailedDiagnostic();
+        input.log?.(
+            buildPostStartIndexLogLine({
+                workflow_id: input.workflow_id,
+                namespace: startOutcome.namespace,
+                workflowId: startOutcome.workflowId,
+                runId: startOutcome.runId,
+                taskQueue: startOutcome.taskQueue,
+                code: diagnostic.code,
+                message: diagnostic.message,
+            })
+        );
+        return { ok: false, diagnostics: [diagnostic] };
+    }
+}


### PR DESCRIPTION
## Summary

- Add `persistAcceptedWorkflowRun` to append `WorkflowRunIndexEntry` records after Temporal accepts a catalog or command-driven start.
- Wire persistence into `WorkflowCatalogCommand` and `RefineIssueCommand`, refreshing the Workflow Runs view on success and surfacing post-start diagnostics when indexing fails or the key already exists.
- Cover successful append, duplicate-key handling, index write failure, and recovery lookup with Vitest.

Closes #79

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (484 passing)
- [ ] Manual: start a workflow from the catalog and confirm a new row appears in Workflow Runs with `recovery_pending`
- [ ] Manual: inspect `{extensionGlobalStorage}/temporal/{windowId}/run-index.json` for the keyed entry
- [ ] Manual: open **View graph** from the new row and confirm recovery refresh behavior