### PR TITLE
Expose View graph from newly started run rows

### DIFF
--- a/src/commands/WorkflowGraphCommand.ts
+++ b/src/commands/WorkflowGraphCommand.ts
@@ -177,6 +177,12 @@ export class WorkflowGraphCommand {
             return;
         }
 
+        const guard = evaluateWorkflowRunAction(entry, 'viewGraph');
+        if (!guard.allowed) {
+            void vscode.window.showWarningMessage(guard.reason ?? 'Run actions are blocked.');
+            return;
+        }
+
         this.sessionState = {
             repositoryRoot: path.resolve(entry.repositoryRoot),
             workflowId: entry.workflow_id,

--- a/src/temporal/workflowRunActions.test.ts
+++ b/src/temporal/workflowRunActions.test.ts
@@ -14,6 +14,7 @@ import { WorkflowRunIndexStore } from './workflowRunIndex';
 import type { TemporalRecoveryClient } from './temporalRecoveryScan';
 import {
     formatHumanInputBlockedMessage,
+    formatOrphanedRunMessage,
     formatRunActionsBlockedMessage,
 } from './temporalPresentation';
 
@@ -60,6 +61,42 @@ afterEach(() => {
 });
 
 describe('workflowRunActions', () => {
+    it('allows view graph only for synced indexed runs', () => {
+        const { globalStoragePath, windowId } = createTempGlobalStorage();
+        const store = new WorkflowRunIndexStore(globalStoragePath, windowId);
+        const entry = createEntry(store);
+
+        expect(evaluateWorkflowRunAction(entry, 'viewGraph').allowed).toBe(false);
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'synced' });
+        const synced = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(synced, 'viewGraph').allowed).toBe(true);
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'recovery_pending' });
+        const recoveryPending = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(recoveryPending, 'viewGraph').reason).toBe(
+            formatRunActionsBlockedMessage()
+        );
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'refresh_failed' });
+        const refreshFailed = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(refreshFailed, 'viewGraph').reason).toBe(
+            formatRunActionsBlockedMessage()
+        );
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'unreachable' });
+        const unreachable = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(unreachable, 'viewGraph').reason).toBe(
+            formatRunActionsBlockedMessage()
+        );
+
+        store.updateEntry('forge-local:wf-1:run-1', { recoveryState: 'orphaned' });
+        const orphaned = store.getEntry('forge-local:wf-1:run-1')!;
+        expect(evaluateWorkflowRunAction(orphaned, 'viewGraph').reason).toBe(
+            formatOrphanedRunMessage()
+        );
+    });
+
     it('blocks cancel, dismiss, and human input while recovery is pending', () => {
         const entry = {
             namespace: 'forge-local',

--- a/src/temporal/workflowRunActions.ts
+++ b/src/temporal/workflowRunActions.ts
@@ -19,7 +19,7 @@ import {
 } from './temporalPresentation';
 import type { TemporalRecoveryClient } from './temporalRecoveryScan';
 
-export type WorkflowRunAction = 'cancel' | 'dismiss' | 'humanInput';
+export type WorkflowRunAction = 'cancel' | 'dismiss' | 'humanInput' | 'viewGraph';
 
 const BLOCKED_RECOVERY_STATES = new Set<RecoveryState>([
     'recovery_pending',
@@ -43,6 +43,31 @@ export function evaluateWorkflowRunAction(
                 reason: formatOrphanedRunMessage(),
             };
         }
+        return { allowed: true };
+    }
+
+    if (action === 'viewGraph') {
+        if (entry.recoveryState === 'orphaned') {
+            return {
+                allowed: false,
+                reason: formatOrphanedRunMessage(),
+            };
+        }
+
+        if (BLOCKED_RECOVERY_STATES.has(entry.recoveryState)) {
+            return {
+                allowed: false,
+                reason: formatRunActionsBlockedMessage(),
+            };
+        }
+
+        if (entry.recoveryState !== 'synced') {
+            return {
+                allowed: false,
+                reason: formatRunActionsBlockedMessage(),
+            };
+        }
+
         return { allowed: true };
     }
 


### PR DESCRIPTION
## Description

Guard **View graph** on Workflow Runs rows by recovery state so operators open the run-mode graph only when the index entry is synced. Recovery-blocked and orphaned rows show existing helper copy instead of stale graph state.

## Motivation and Context

Closes #82. After Start Run succeeds (#81), users choose when to open the graph from the run list. The menu entry stays visible for all indexed rows; the command handler enforces blocked behavior per `.ai/interface/presentation.md`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## How Has This Been Tested?

- [x] Unit tests added/updated (`npm test`)
- [x] All new and existing tests pass (`npm test` — 494 tests)
- [x] Linter passes (`npm run lint`)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass (`npm test`)
- [x] I have run the linter and fixed any issues (`npm run lint`)

## Additional Notes

- `evaluateWorkflowRunAction` gains a `viewGraph` action used by `WorkflowGraphCommand.openGraphForRun`.
- `package.json` already exposes **View graph** for all `forge.workflowRunList` rows; no menu change required.
- Catalog Start Run path does not invoke graph open (unchanged from #83).